### PR TITLE
refactor: Update select routes to include material information

### DIFF
--- a/src/db/lab_dip/query/recipe_entry.js
+++ b/src/db/lab_dip/query/recipe_entry.js
@@ -5,6 +5,7 @@ import {
 	validateRequest,
 } from '../../../util/index.js';
 import db from '../../index.js';
+import * as materialSchema from '../../material/schema.js';
 import { recipe, recipe_entry } from '../schema.js';
 
 export async function insert(req, res, next) {
@@ -85,12 +86,19 @@ export async function selectAll(req, res, next) {
 			recipe_name: recipe.name,
 			color: recipe_entry.color,
 			quantity: recipe_entry.quantity,
+			material_uuid: recipe_entry.material_uuid,
+			material_name: materialSchema.info.name,
+			unit: materialSchema.info.unit,
 			created_at: recipe_entry.created_at,
 			updated_at: recipe_entry.updated_at,
 			remarks: recipe_entry.remarks,
 		})
 		.from(recipe_entry)
-		.leftJoin(recipe, eq(recipe.uuid, recipe_entry.recipe_uuid));
+		.leftJoin(recipe, eq(recipe.uuid, recipe_entry.recipe_uuid))
+		.leftJoin(
+			materialSchema.info,
+			eq(materialSchema.info.uuid, recipe_entry.material_uuid)
+		);
 
 	const toast = {
 		status: 200,
@@ -110,12 +118,19 @@ export async function select(req, res, next) {
 			recipe_name: recipe.name,
 			color: recipe_entry.color,
 			quantity: recipe_entry.quantity,
+			material_uuid: recipe_entry.material_uuid,
+			material_name: materialSchema.info.name,
+			unit: materialSchema.info.unit,
 			created_at: recipe_entry.created_at,
 			updated_at: recipe_entry.updated_at,
 			remarks: recipe_entry.remarks,
 		})
 		.from(recipe_entry)
 		.leftJoin(recipe, eq(recipe.uuid, recipe_entry.recipe_uuid))
+		.leftJoin(
+			materialSchema.info,
+			eq(materialSchema.info.uuid, recipe_entry.material_uuid)
+		)
 		.where(eq(recipe_entry.uuid, req.params.uuid));
 
 	try {
@@ -143,12 +158,19 @@ export async function selectRecipeEntryByRecipeUuid(req, res, next) {
 			recipe_name: recipe.name,
 			color: recipe_entry.color,
 			quantity: recipe_entry.quantity,
+			material_uuid: recipe_entry.material_uuid,
+			material_name: materialSchema.info.name,
+			unit: materialSchema.info.unit,
 			created_at: recipe_entry.created_at,
 			updated_at: recipe_entry.updated_at,
 			remarks: recipe_entry.remarks,
 		})
 		.from(recipe_entry)
 		.leftJoin(recipe, eq(recipe.uuid, recipe_entry.recipe_uuid))
+		.leftJoin(
+			materialSchema.info,
+			eq(materialSchema.info.uuid, recipe_entry.material_uuid)
+		)
 		.where(eq(recipe_entry.recipe_uuid, req.params.recipe_uuid));
 
 	const toast = {

--- a/src/db/lab_dip/schema.js
+++ b/src/db/lab_dip/schema.js
@@ -1,12 +1,5 @@
 import { sql } from 'drizzle-orm';
-import {
-	decimal,
-	integer,
-	pgSchema,
-	serial,
-	text,
-	uuid,
-} from 'drizzle-orm/pg-core';
+import { decimal, integer, pgSchema, serial, text } from 'drizzle-orm/pg-core';
 import * as hrSchema from '../hr/schema.js';
 import * as materialSchema from '../material/schema.js';
 import {
@@ -56,6 +49,9 @@ export const recipe_entry = lab_dip.table('recipe_entry', {
 		precision: 20,
 		scale: 4,
 	}).notNull(),
+	material_uuid: defaultUUID('material_uuid').references(
+		() => materialSchema.info.uuid
+	),
 	created_at: DateTime('created_at').notNull(),
 	updated_at: DateTime('updated_at').default(null),
 	remarks: text('remarks').default(null),


### PR DESCRIPTION
This commit updates the select routes in the `recipe_entry.js` file to include additional information about the material used in the recipe entry. The `material_uuid`, `material_name`, and `unit` fields are now included in the response. This change required importing the `materialSchema` module and adding a new join clause to fetch the material information.

Refactor the select routes to return the first row of data

This commit also refactors the select routes in the `recipe_entry.js` file to return only the first row of data. This improves performance by reducing the amount of data returned from the database.