### PR TITLE
Fix SQL join reference in batch transaction query

### DIFF
--- a/src/db/zipper/query/finishing_batch_transaction.js
+++ b/src/db/zipper/query/finishing_batch_transaction.js
@@ -289,7 +289,7 @@ export async function selectByTrxFrom(req, res, next) {
 		LEFT JOIN
 			hr.users ON finishing_batch_transaction.created_by = users.uuid
 		LEFT JOIN
-			zipper.finishing_batch_entry fbe ON finishing_batch_transaction.finishing_batch_entry_uuid = finishing_batch_entry.uuid
+			zipper.finishing_batch_entry fbe ON finishing_batch_transaction.finishing_batch_entry_uuid = fbe.uuid
 		LEFT JOIN 
 			zipper.finishing_batch zfb ON fbe.finishing_batch_uuid = zfb.uuid
 		LEFT JOIN


### PR DESCRIPTION
Correct the SQL join reference in the finishing batch transaction query to ensure consistency. This change improves the accuracy of data retrieval.