### PR TITLE
Remove unused handleResponse imports for code cleanup

### DIFF
--- a/src/db/lab_dip/query/shade_recipe.js
+++ b/src/db/lab_dip/query/shade_recipe.js
@@ -2,7 +2,6 @@ import { desc, eq, sql } from 'drizzle-orm';
 import { createApi } from '../../../util/api.js';
 import {
 	handleError,
-	handleResponse,
 	validateRequest,
 } from '../../../util/index.js';
 import * as hrSchema from '../../hr/schema.js';
@@ -99,14 +98,17 @@ export async function selectAll(req, res, next) {
 			eq(shade_recipe.created_by, hrSchema.users.uuid)
 		)
 		.orderBy(desc(shade_recipe.created_at));
-
-	const toast = {
-		status: 200,
-		type: 'select_all',
-		message: 'shade_recipe list',
-	};
-
-	handleResponse({ promise: resultPromise, res, next, ...toast });
+	try {
+		const data = await resultPromise;
+		const toast = {
+			status: 200,
+			type: 'select_all',
+			message: 'shade_recipe list',
+		};
+		return await res.status(200).json({ toast, data });
+	} catch (error) {
+		handleError({ error, res });
+	}
 }
 
 export async function select(req, res, next) {
@@ -178,7 +180,6 @@ export async function selectShadeRecipeDetailsByShadeRecipeUuid(
 		const response = {
 			...shade_recipe?.data?.data,
 			shade_recipe_entry: shade_recipe_entry?.data?.data || [],
-
 		};
 
 		const toast = {

--- a/src/db/lab_dip/query/shade_recipe_entry.js
+++ b/src/db/lab_dip/query/shade_recipe_entry.js
@@ -1,7 +1,6 @@
 import { desc, eq } from 'drizzle-orm';
 import {
 	handleError,
-	handleResponse,
 	validateRequest,
 } from '../../../util/index.js';
 import db from '../../index.js';
@@ -188,11 +187,16 @@ export async function selectShadeRecipeEntryByShadeRecipeUuid(req, res, next) {
 			)
 		);
 
-	const toast = {
-		status: 200,
-		type: 'select_all',
-		message: 'shade_recipe_entry list',
-	};
+	try {
+		const data = await resultPromise;
+		const toast = {
+			status: 200,
+			type: 'select_all',
+			message: 'shade_recipe_entry list',
+		};
 
-	handleResponse({ promise: resultPromise, res, next, ...toast });
+		return await res.status(200).json({ toast, data });
+	} catch (error) {
+		await handleError({ error, res });
+	}
 }

--- a/src/db/material/query/booking.js
+++ b/src/db/material/query/booking.js
@@ -1,7 +1,6 @@
 import { asc, desc, eq, sql } from 'drizzle-orm';
 import {
 	handleError,
-	handleResponse,
 	validateRequest,
 } from '../../../util/index.js';
 import * as hrSchema from '../../hr/schema.js';

--- a/src/db/material/query/info.js
+++ b/src/db/material/query/info.js
@@ -2,7 +2,6 @@ import { asc, desc, eq } from 'drizzle-orm';
 import { description } from '../../../db/purchase/schema.js';
 import {
 	handleError,
-	handleResponse,
 	validateRequest,
 } from '../../../util/index.js';
 import * as hrSchema from '../../hr/schema.js';

--- a/src/db/material/query/section.js
+++ b/src/db/material/query/section.js
@@ -1,7 +1,6 @@
 import { asc, desc, eq } from 'drizzle-orm';
 import {
 	handleError,
-	handleResponse,
 	validateRequest,
 } from '../../../util/index.js';
 import * as hrSchema from '../../hr/schema.js';
@@ -91,14 +90,18 @@ export async function selectAll(req, res, next) {
 		.from(section)
 		.leftJoin(hrSchema.users, eq(hrSchema.users.uuid, section.created_by))
 		.orderBy(asc(section.name));
+	try {
+		const data = await resultPromise;
+		const toast = {
+			status: 200,
+			type: 'select_all',
+			message: 'Section list',
+		};
 
-	const toast = {
-		status: 200,
-		type: 'select_all',
-		message: 'Section list',
-	};
-
-	handleResponse({ promise: resultPromise, res, next, ...toast });
+		return await res.status(200).json({ toast, data });
+	} catch (error) {
+		await handleError({ error, res });
+	}
 }
 
 export async function select(req, res, next) {

--- a/src/db/material/query/stock.js
+++ b/src/db/material/query/stock.js
@@ -2,7 +2,6 @@ import { desc, eq, gt, lt, sql } from 'drizzle-orm';
 import { createApi } from '../../../util/api.js';
 import {
 	handleError,
-	handleResponse,
 	validateRequest,
 } from '../../../util/index.js';
 import db from '../../index.js';
@@ -115,14 +114,18 @@ export async function selectAll(req, res, next) {
 		.from(stock)
 		.leftJoin(info, eq(stock.material_uuid, info.uuid))
 		.orderBy(desc(stock.created_at));
+	try {
+		const data = await resultPromise;
+		const toast = {
+			status: 200,
+			type: 'select_all',
+			message: 'Stock list',
+		};
 
-	const toast = {
-		status: 200,
-		type: 'select_all',
-		message: 'Stock list',
-	};
-
-	handleResponse({ promise: resultPromise, res, next, ...toast });
+		return await res.status(200).json({ toast, data });
+	} catch (error) {
+		await handleError({ error, res });
+	}
 }
 
 export async function select(req, res, next) {
@@ -194,14 +197,18 @@ export async function selectMaterialBelowThreshold(req, res, next) {
 		.from(stock)
 		.innerJoin(info, eq(stock.material_uuid, info.uuid))
 		.where(lt(stock.stock, info.threshold));
+	try {
+		const data = await stockPromise;
+		const toast = {
+			status: 200,
+			type: 'select_all',
+			message: 'Material below threshold',
+		};
 
-	const toast = {
-		status: 200,
-		type: 'select_all',
-		message: 'Material below threshold',
-	};
-
-	handleResponse({ promise: stockPromise, res, next, ...toast });
+		return await res.status(200).json({ toast, data });
+	} catch (error) {
+		await handleError({ error, res });
+	}
 }
 
 export async function selectMaterialStockForAFieldName(req, res, next) {
@@ -223,13 +230,18 @@ export async function selectMaterialStockForAFieldName(req, res, next) {
 		.leftJoin(info, eq(stock.material_uuid, info.uuid))
 		.where(sql`stock.${sql.raw(fieldName)} > 0`);
 
-	const toast = {
-		status: 200,
-		type: 'select',
-		message: 'Stock',
-	};
+	try {
+		const data = await stockPromise;
+		const toast = {
+			status: 200,
+			type: 'select',
+			message: 'Stock',
+		};
 
-	handleResponse({ promise: stockPromise, res, next, ...toast });
+		return await res.status(200).json({ toast, data });
+	} catch (error) {
+		await handleError({ error, res });
+	}
 }
 
 export async function selectMaterialStockForMultiFieldNames(req, res, next) {

--- a/src/db/material/query/stock_to_sfg.js
+++ b/src/db/material/query/stock_to_sfg.js
@@ -1,7 +1,6 @@
 import { eq, sql } from 'drizzle-orm';
 import {
 	handleError,
-	handleResponse,
 	validateRequest,
 } from '../../../util/index.js';
 import db from '../../index.js';

--- a/src/db/material/query/trx.js
+++ b/src/db/material/query/trx.js
@@ -1,7 +1,6 @@
 import { and, desc, eq, sql } from 'drizzle-orm';
 import {
 	handleError,
-	handleResponse,
 	validateRequest,
 } from '../../../util/index.js';
 import * as hrSchema from '../../hr/schema.js';

--- a/src/db/material/query/type.js
+++ b/src/db/material/query/type.js
@@ -1,7 +1,6 @@
 import { desc, eq } from 'drizzle-orm';
 import {
 	handleError,
-	handleResponse,
 	validateRequest,
 } from '../../../util/index.js';
 import * as hrSchema from '../../hr/schema.js';
@@ -90,13 +89,18 @@ export async function selectAll(req, res, next) {
 		.leftJoin(hrSchema.users, eq(hrSchema.users.uuid, type.created_by))
 		.orderBy(desc(type.created_at));
 
-	const toast = {
-		status: 200,
-		type: 'select_all',
-		message: 'Type list',
-	};
+	try {
+		const data = await resultPromise;
+		const toast = {
+			status: 200,
+			type: 'select_all',
+			message: 'Type list',
+		};
 
-	handleResponse({ promise: resultPromise, res, next, ...toast });
+		return await res.status(200).json({ toast, data });
+	} catch (error) {
+		await handleError({ error, res });
+	}
 }
 
 export async function select(req, res, next) {

--- a/src/db/material/query/used.js
+++ b/src/db/material/query/used.js
@@ -2,7 +2,6 @@ import { desc, eq, sql } from 'drizzle-orm';
 import { createApi } from '../../../util/api.js';
 import {
 	handleError,
-	handleResponse,
 	validateRequest,
 } from '../../../util/index.js';
 import * as hrSchema from '../../hr/schema.js';
@@ -156,13 +155,20 @@ export async function selectAll(req, res, next) {
 		.leftJoin(stock, eq(used.material_uuid, stock.material_uuid))
 		.leftJoin(hrSchema.users, eq(used.created_by, hrSchema.users.uuid))
 		.orderBy(desc(used.created_at));
-	const toast = {
-		status: 200,
-		type: 'select_all',
-		message: 'Used list',
-	};
 
-	handleResponse({ promise: resultPromise, res, next, ...toast });
+	try {
+		const data = await resultPromise;
+
+		const toast = {
+			status: 200,
+			type: 'select_all',
+			message: 'Used list',
+		};
+
+		return await res.status(200).json({ toast, data });
+	} catch (error) {
+		await handleError({ error, res });
+	}
 }
 
 export async function select(req, res, next) {
@@ -286,14 +292,19 @@ export async function selectUsedBySection(req, res, next) {
 		.leftJoin(stock, eq(used.material_uuid, stock.material_uuid))
 		.leftJoin(hrSchema.users, eq(used.created_by, hrSchema.users.uuid))
 		.where(eq(used.section, req.params.section));
+	try {
+		const data = await usedPromise;
 
-	const toast = {
-		status: 200,
-		type: 'select',
-		message: 'Used',
-	};
+		const toast = {
+			status: 200,
+			type: 'select',
+			message: 'Used',
+		};
 
-	handleResponse({ promise: usedPromise, res, next, ...toast });
+		return await res.status(200).json({ toast, data });
+	} catch (error) {
+		await handleError({ error, res });
+	}
 }
 
 export async function selectUsedForMultipleSection(req, res, next) {

--- a/src/db/others/query/query.js
+++ b/src/db/others/query/query.js
@@ -2,7 +2,6 @@ import { and, eq, min, or, sql, sum } from 'drizzle-orm';
 import { alias } from 'drizzle-orm/pg-core';
 import {
 	handleError,
-	handleResponse,
 	validateRequest,
 } from '../../../util/index.js';
 import db from '../../index.js';
@@ -38,18 +37,17 @@ export async function selectMachine(req, res, next) {
 			min_capacity: decimalToNumber(publicSchema.machine.min_capacity),
 		})
 		.from(publicSchema.machine);
-
-	const toast = {
-		status: 200,
-		type: 'select_all',
-		message: 'Machine list',
-	};
-	handleResponse({
-		promise: machinePromise,
-		res,
-		next,
-		...toast,
-	});
+	try {
+		const data = await machinePromise;
+		const toast = {
+			status: 200,
+			type: 'select_all',
+			message: 'Machine list',
+		};
+		return await res.status(200).json({ toast, data: data });
+	} catch (error) {
+		await handleError({ error, res });
+	}
 }
 
 export async function selectParty(req, res, next) {
@@ -105,13 +103,18 @@ export async function selectMarketingUser(req, res, next) {
 		)
 		.where(eq(hrSchema.department.department, 'Sales And Marketing'));
 
-	const toast = {
-		status: 200,
-		type: 'select',
-		message: 'marketing user',
-	};
+	try {
+		const data = await userPromise;
+		const toast = {
+			status: 200,
+			type: 'select',
+			message: 'marketing user',
+		};
 
-	handleResponse({ promise: userPromise, res, next, ...toast });
+		return await res.status(200).json({ toast, data });
+	} catch (error) {
+		await handleError({ error, res });
+	}
 }
 
 export async function selectBuyer(req, res, next) {
@@ -122,17 +125,17 @@ export async function selectBuyer(req, res, next) {
 		})
 		.from(publicSchema.buyer);
 
-	const toast = {
-		status: 200,
-		type: 'select_all',
-		message: 'Buyer list',
-	};
-	handleResponse({
-		promise: buyerPromise,
-		res,
-		next,
-		...toast,
-	});
+	try {
+		const data = await buyerPromise;
+		const toast = {
+			status: 200,
+			type: 'select_all',
+			message: 'Buyer list',
+		};
+		return await res.status(200).json({ toast, data });
+	} catch (error) {
+		await handleError({ error, res });
+	}
 }
 
 export async function selectSpecificMerchandiser(req, res, next) {
@@ -745,17 +748,19 @@ export async function selectMaterialSection(req, res, next) {
 		})
 		.from(materialSchema.section);
 
-	const toast = {
-		status: 200,
-		type: 'select_all',
-		message: 'Section list',
-	};
-	handleResponse({
-		promise: sectionPromise,
-		res,
-		next,
-		...toast,
-	});
+	try {
+		const data = await sectionPromise;
+
+		const toast = {
+			status: 200,
+			type: 'select_all',
+			message: 'Section list',
+		};
+
+		return await res.status(200).json({ toast, data: data });
+	} catch (error) {
+		await handleError({ error, res });
+	}
 }
 
 export async function selectMaterialType(req, res, next) {
@@ -766,17 +771,19 @@ export async function selectMaterialType(req, res, next) {
 		})
 		.from(materialSchema.type);
 
-	const toast = {
-		status: 200,
-		type: 'select_all',
-		message: 'Type list',
-	};
-	handleResponse({
-		promise: typePromise,
-		res,
-		next,
-		...toast,
-	});
+	try {
+		const data = await typePromise;
+
+		const toast = {
+			status: 200,
+			type: 'select_all',
+			message: 'Type list',
+		};
+
+		return await res.status(200).json({ toast, data: data });
+	} catch (error) {
+		await handleError({ error, res });
+	}
 }
 
 export async function selectMaterial(req, res, next) {
@@ -839,17 +846,19 @@ export async function selectBank(req, res, next) {
 		})
 		.from(commercialSchema.bank);
 
-	const toast = {
-		status: 200,
-		type: 'select_all',
-		message: 'Bank list',
-	};
-	handleResponse({
-		promise: bankPromise,
-		res,
-		next,
-		...toast,
-	});
+	try {
+		const data = await bankPromise;
+
+		const toast = {
+			status: 200,
+			type: 'select_all',
+			message: 'Bank list',
+		};
+
+		return await res.status(200).json({ toast, data: data });
+	} catch (error) {
+		await handleError({ error, res });
+	}
 }
 
 export async function selectLCByPartyUuid(req, res, next) {
@@ -861,17 +870,19 @@ export async function selectLCByPartyUuid(req, res, next) {
 		.from(commercialSchema.lc)
 		.where(eq(commercialSchema.lc.party_uuid, req.params.party_uuid));
 
-	const toast = {
-		status: 200,
-		type: 'select',
-		message: 'LC list of a party',
-	};
-	handleResponse({
-		promise: lcPromise,
-		res,
-		next,
-		...toast,
-	});
+	try {
+		const data = await lcPromise;
+
+		const toast = {
+			status: 200,
+			type: 'select_all',
+			message: 'LC list',
+		};
+
+		return await res.status(200).json({ toast, data });
+	} catch (error) {
+		await handleError({ error, res });
+	}
 }
 
 export async function selectPi(req, res, next) {
@@ -941,17 +952,19 @@ export async function selectDepartment(req, res, next) {
 		})
 		.from(hrSchema.department);
 
-	const toast = {
-		status: 200,
-		type: 'select_all',
-		message: 'Department list',
-	};
-	handleResponse({
-		promise: departmentPromise,
-		res,
-		next,
-		...toast,
-	});
+	try {
+		const data = await departmentPromise;
+
+		const toast = {
+			status: 200,
+			type: 'select_all',
+			message: 'Department list',
+		};
+
+		return await res.status(200).json({ toast, data: data });
+	} catch (error) {
+		await handleError({ error, res });
+	}
 }
 //* HR User *//
 export async function selectHrUser(req, res, next) {
@@ -997,17 +1010,19 @@ export async function selectDesignation(req, res, next) {
 		})
 		.from(hrSchema.designation);
 
-	const toast = {
-		status: 200,
-		type: 'select_all',
-		message: 'Designation list',
-	};
-	handleResponse({
-		promise: Designation,
-		res,
-		next,
-		...toast,
-	});
+	try {
+		const data = await Designation;
+
+		const toast = {
+			status: 200,
+			type: 'select_all',
+			message: 'Designation list',
+		};
+
+		return await res.status(200).json({ toast, data: data });
+	} catch (error) {
+		await handleError({ error, res });
+	}
 }
 
 // * Lab Dip * //
@@ -1143,18 +1158,19 @@ export async function selectLabDipInfo(req, res, next) {
 		})
 		.from(labDipSchema.info);
 
-	const toast = {
-		status: 200,
-		type: 'select_all',
-		message: 'Info list',
-	};
+	try {
+		const data = await InfoPromise;
 
-	handleResponse({
-		promise: InfoPromise,
-		res,
-		next,
-		...toast,
-	});
+		const toast = {
+			status: 200,
+			type: 'select_all',
+			message: 'Lab Dip Info list',
+		};
+
+		return await res.status(200).json({ toast, data: data });
+	} catch (error) {
+		await handleError({ error, res });
+	}
 }
 
 // * Slider * //
@@ -1419,18 +1435,19 @@ export async function selectBatchId(req, res, next) {
 		})
 		.from(threadSchema.batch);
 
-	const toast = {
-		status: 200,
-		type: 'select_all',
-		message: 'Batch Id list',
-	};
+	try {
+		const data = await batchIdPromise;
 
-	handleResponse({
-		promise: batchIdPromise,
-		res,
-		next,
-		...toast,
-	});
+		const toast = {
+			status: 200,
+			type: 'select_all',
+			message: 'Batch Id list',
+		};
+
+		return await res.status(200).json({ toast, data: data });
+	} catch (error) {
+		await handleError({ error, res });
+	}
 }
 
 // Dyes Category
@@ -1442,17 +1459,19 @@ export async function selectDyesCategory(req, res, next) {
 		})
 		.from(threadSchema.dyes_category);
 
-	const toast = {
-		status: 200,
-		type: 'select_all',
-		message: 'Dyes Category list',
-	};
-	handleResponse({
-		promise: dyesCategoryPromise,
-		res,
-		next,
-		...toast,
-	});
+	try {
+		const data = await dyesCategoryPromise;
+
+		const toast = {
+			status: 200,
+			type: 'select_all',
+			message: 'Dyes Category list',
+		};
+
+		return await res.status(200).json({ toast, data: data });
+	} catch (error) {
+		await handleError({ error, res });
+	}
 }
 
 // * Delivery * //
@@ -1506,17 +1525,19 @@ export async function selectVehicle(req, res, next) {
 		})
 		.from(deliverySchema.vehicle);
 
-	const toast = {
-		status: 200,
-		type: 'select_all',
-		message: 'Vehicle list',
-	};
-	handleResponse({
-		promise: vehiclePromise,
-		res,
-		next,
-		...toast,
-	});
+	try {
+		const data = await vehiclePromise;
+
+		const toast = {
+			status: 200,
+			type: 'select_all',
+			message: 'Vehicle list',
+		};
+
+		return await res.status(200).json({ toast, data: data });
+	} catch (error) {
+		await handleError({ error, res });
+	}
 }
 
 export async function selectCarton(req, res, next) {
@@ -1527,15 +1548,17 @@ export async function selectCarton(req, res, next) {
 		})
 		.from(deliverySchema.carton);
 
-	const toast = {
-		status: 200,
-		type: 'select_all',
-		message: 'Carton list',
-	};
-	handleResponse({
-		promise: cartonPromise,
-		res,
-		next,
-		...toast,
-	});
+	try {
+		const data = await cartonPromise;
+
+		const toast = {
+			status: 200,
+			type: 'select_all',
+			message: 'Carton list',
+		};
+
+		return await res.status(200).json({ toast, data: data });
+	} catch (error) {
+		await handleError({ error, res });
+	}
 }

--- a/src/db/public/query/buyer.js
+++ b/src/db/public/query/buyer.js
@@ -1,7 +1,6 @@
 import { desc, eq } from 'drizzle-orm';
 import {
 	handleError,
-	handleResponse,
 	validateRequest,
 } from '../../../util/index.js';
 import * as hrSchema from '../../hr/schema.js';
@@ -100,18 +99,19 @@ export async function selectAll(req, res, next) {
 		.from(buyer)
 		.leftJoin(hrSchema.users, eq(buyer.created_by, hrSchema.users.uuid))
 		.orderBy(desc(buyer.created_at));
-	const toast = {
-		status: 200,
-		type: 'select_all',
-		message: 'Buyer list',
-	};
 
-	handleResponse({
-		promise: buyerPromise,
-		res,
-		next,
-		...toast,
-	});
+	try {
+		const data = await buyerPromise;
+		const toast = {
+			status: 200,
+			type: 'select_all',
+			message: 'Buyer',
+		};
+
+		return await res.status(200).json({ toast, data });
+	} catch (error) {
+		await handleError({ error, res });
+	}
 }
 
 export async function select(req, res, next) {

--- a/src/db/public/query/factory.js
+++ b/src/db/public/query/factory.js
@@ -1,7 +1,6 @@
 import { desc, eq } from 'drizzle-orm';
 import {
 	handleError,
-	handleResponse,
 	validateRequest,
 } from '../../../util/index.js';
 import * as hrSchema from '../../hr/schema.js';
@@ -100,17 +99,18 @@ export async function selectAll(req, res, next) {
 		.leftJoin(party, eq(factory.party_uuid, party.uuid))
 		.leftJoin(hrSchema.users, eq(factory.created_by, hrSchema.users.uuid))
 		.orderBy(desc(factory.created_at));
-	const toast = {
-		status: 200,
-		type: 'select_all',
-		message: 'Factory list',
-	};
-	handleResponse({
-		promise: resultPromise,
-		res,
-		next,
-		...toast,
-	});
+
+	try {
+		const data = await resultPromise;
+		const toast = {
+			status: 200,
+			type: 'select_all',
+			message: 'All factories',
+		};
+		return await res.status(200).json({ toast, data });
+	} catch (error) {
+		await handleError({ error, res });
+	}
 }
 
 export async function select(req, res, next) {

--- a/src/db/public/query/machine.js
+++ b/src/db/public/query/machine.js
@@ -2,7 +2,6 @@ import { desc, eq, sql } from 'drizzle-orm';
 import { createApi } from '../../../util/api.js';
 import {
 	handleError,
-	handleResponse,
 	validateRequest,
 } from '../../../util/index.js';
 import * as hrSchema from '../../hr/schema.js';
@@ -91,7 +90,7 @@ export async function selectAll(req, res, next) {
 			is_sample: machine.is_sample,
 			max_capacity: decimalToNumber(machine.max_capacity),
 			min_capacity: decimalToNumber(machine.min_capacity),
-			water_capacity:decimalToNumber(machine.water_capacity),
+			water_capacity: decimalToNumber(machine.water_capacity),
 			created_by: machine.created_by,
 			created_by_name: hrSchema.users.name,
 			created_at: machine.created_at,
@@ -102,13 +101,18 @@ export async function selectAll(req, res, next) {
 		.leftJoin(hrSchema.users, eq(machine.created_by, hrSchema.users.uuid))
 		.orderBy(desc(machine.created_at));
 
-	const toast = {
-		status: 200,
-		type: 'select_all',
-		message: 'Machine list',
-	};
+	try {
+		const data = await resultPromise;
+		const toast = {
+			status: 200,
+			type: 'select_all',
+			message: 'Machine',
+		};
 
-	handleResponse({ promise: resultPromise, res, next, ...toast });
+		return await res.status(200).json({ toast, data });
+	} catch (error) {
+		await handleError({ error, res });
+	}
 }
 
 export async function select(req, res, next) {

--- a/src/db/public/query/marketing.js
+++ b/src/db/public/query/marketing.js
@@ -2,7 +2,6 @@ import { desc, eq } from 'drizzle-orm';
 import { alias } from 'drizzle-orm/pg-core';
 import {
 	handleError,
-	handleResponse,
 	validateRequest,
 } from '../../../util/index.js';
 import * as hrSchema from '../../hr/schema.js';
@@ -102,18 +101,18 @@ export async function selectAll(req, res, next) {
 		)
 		.orderBy(desc(marketing.created_at));
 
-	const toast = {
-		status: 200,
-		type: 'select_all',
-		message: 'Marketing list',
-	};
+	try {
+		const data = await resultPromise;
+		const toast = {
+			status: 200,
+			type: 'select_all',
+			message: 'Marketing list',
+		};
 
-	handleResponse({
-		promise: resultPromise,
-		res,
-		next,
-		...toast,
-	});
+		return await res.status(200).json({ toast, data });
+	} catch (error) {
+		await handleError({ error, res });
+	}
 }
 
 export async function select(req, res, next) {

--- a/src/db/public/query/merchandiser.js
+++ b/src/db/public/query/merchandiser.js
@@ -1,7 +1,6 @@
 import { between, desc, eq, sql } from 'drizzle-orm';
 import {
 	handleError,
-	handleResponse,
 	validateRequest,
 } from '../../../util/index.js';
 import * as hrSchema from '../../hr/schema.js';

--- a/src/db/public/query/party.js
+++ b/src/db/public/query/party.js
@@ -1,7 +1,6 @@
 import { desc, eq } from 'drizzle-orm';
 import {
 	handleError,
-	handleResponse,
 	validateRequest,
 } from '../../../util/index.js';
 import * as hrSchema from '../../hr/schema.js';
@@ -102,17 +101,18 @@ export async function selectAll(req, res, next) {
 		.leftJoin(hrSchema.users, eq(party.created_by, hrSchema.users.uuid))
 		.orderBy(desc(party.created_at));
 
-	const toast = {
-		status: 200,
-		type: 'select_all',
-		message: 'Party list',
-	};
-	handleResponse({
-		promise: resultPromise,
-		res,
-		next,
-		...toast,
-	});
+	try {
+		const data = await resultPromise;
+		const toast = {
+			status: 200,
+			type: 'select_all',
+			message: 'Party list',
+		};
+
+		return await res.status(200).json({ toast, data });
+	} catch (error) {
+		await handleError({ error, res });
+	}
 }
 
 export async function select(req, res, next) {

--- a/src/db/public/query/properties.js
+++ b/src/db/public/query/properties.js
@@ -1,7 +1,6 @@
 import { desc, eq } from 'drizzle-orm';
 import {
 	handleError,
-	handleResponse,
 	validateRequest,
 } from '../../../util/index.js';
 import * as hrSchema from '../../hr/schema.js';
@@ -96,17 +95,17 @@ export async function selectAll(req, res, next) {
 		)
 		.orderBy(desc(properties.created_at));
 
-	const toast = {
-		status: 200,
-		type: 'select_all',
-		message: 'Property list',
-	};
-	handleResponse({
-		promise: resultPromise,
-		res,
-		next,
-		...toast,
-	});
+	try {
+		const data = await resultPromise;
+		const toast = {
+			status: 200,
+			type: 'select_all',
+			message: 'Properties list',
+		};
+		return await res.status(200).json({ toast, data });
+	} catch (error) {
+		await handleError({ error, res });
+	}
 }
 
 export async function select(req, res, next) {

--- a/src/db/public/query/section.js
+++ b/src/db/public/query/section.js
@@ -1,7 +1,6 @@
 import { eq } from 'drizzle-orm';
 import {
 	handleError,
-	handleResponse,
 	validateRequest,
 } from '../../../util/index.js';
 import db from '../../index.js';
@@ -77,13 +76,18 @@ export async function remove(req, res, next) {
 export async function selectAll(req, res, next) {
 	const resultPromise = db.select().from(section);
 
-	const toast = {
-		status: 200,
-		type: 'select',
-		message: 'Sections list',
-	};
+	try {
+		const data = await resultPromise;
+		const toast = {
+			status: 200,
+			type: 'select',
+			message: 'Sections list',
+		};
 
-	handleResponse({ promise: resultPromise, res, next, ...toast });
+		return await res.status(200).json({ toast, data });
+	} catch (error) {
+		await handleError({ error, res });
+	}
 }
 
 export async function select(req, res, next) {

--- a/src/db/public/swagger/route.js
+++ b/src/db/public/swagger/route.js
@@ -1,7 +1,7 @@
 import SE from '../../../util/swagger_example.js';
 // * Public Buyer * //
 const pathPublicBuyer = {
-	'/public/public/buyer': {
+	'/public/buyer': {
 		get: {
 			summary: 'Get all buyers',
 			tags: ['public.buyer'],
@@ -44,7 +44,7 @@ const pathPublicBuyer = {
 			},
 		},
 	},
-	'/public/buyer/{uuid}': {
+	'/public/{uuid}': {
 		get: {
 			summary: 'Get a buyer',
 			tags: ['public.buyer'],

--- a/src/db/purchase/query/description.js
+++ b/src/db/purchase/query/description.js
@@ -2,7 +2,6 @@ import { desc, eq, sql } from 'drizzle-orm';
 import { createApi } from '../../../util/api.js';
 import {
 	handleError,
-	handleResponse,
 	validateRequest,
 } from '../../../util/index.js';
 import * as hrSchema from '../../hr/schema.js';
@@ -107,13 +106,17 @@ export async function selectAll(req, res, next) {
 		)
 		.orderBy(desc(description.created_at));
 
-	const toast = {
-		status: 200,
-		type: 'select_all',
-		message: 'Description list',
-	};
-
-	handleResponse({ promise: resultPromise, res, next, ...toast });
+	try {
+		const data = await resultPromise;
+		const toast = {
+			status: 200,
+			type: 'select_all',
+			message: 'Description list',
+		};
+		return await res.status(200).json({ toast, data });
+	} catch (error) {
+		await handleError({ error, res });
+	}
 }
 
 export async function select(req, res, next) {

--- a/src/db/purchase/query/entry.js
+++ b/src/db/purchase/query/entry.js
@@ -1,7 +1,6 @@
 import { desc, eq, sql } from 'drizzle-orm';
 import {
 	handleError,
-	handleResponse,
 	validateRequest,
 } from '../../../util/index.js';
 import * as hrSchema from '../../hr/schema.js';
@@ -98,13 +97,18 @@ export async function selectAll(req, res, next) {
 		)
 		.orderBy(desc(entry.created_at));
 
-	const toast = {
-		status: 200,
-		type: 'select_all',
-		message: 'Entry list',
-	};
+	try {
+		const data = await resultPromise;
+		const toast = {
+			status: 200,
+			type: 'select_all',
+			message: 'Entry list',
+		};
 
-	handleResponse({ promise: resultPromise, res, next, ...toast });
+		return await res.status(200).json({ toast, data });
+	} catch (error) {
+		await handleError({ error, res });
+	}
 }
 
 export async function select(req, res, next) {
@@ -173,11 +177,16 @@ export async function selectEntryByPurchaseDescriptionUuid(req, res, next) {
 		)
 		.orderBy(desc(entry.created_at));
 
-	const toast = {
-		status: 200,
-		type: 'select',
-		message: 'Entry',
-	};
+	try {
+		const data = await entryPromise;
+		const toast = {
+			status: 200,
+			type: 'select',
+			message: 'Entry by purchase description uuid',
+		};
 
-	handleResponse({ promise: entryPromise, res, next, ...toast });
+		return await res.status(200).json({ toast, data });
+	} catch (error) {
+		await handleError({ error, res });
+	}
 }

--- a/src/db/purchase/query/vendor.js
+++ b/src/db/purchase/query/vendor.js
@@ -1,7 +1,6 @@
 import { asc, desc, eq } from 'drizzle-orm';
 import {
 	handleError,
-	handleResponse,
 	validateRequest,
 } from '../../../util/index.js';
 import * as hrSchema from '../../hr/schema.js';
@@ -88,12 +87,18 @@ export async function selectAll(req, res, next) {
 		.from(vendor)
 		.leftJoin(hrSchema.users, eq(hrSchema.users.uuid, vendor.created_by))
 		.orderBy(asc(vendor.name));
-	const toast = {
-		status: 200,
-		type: 'select_all',
-		message: 'Vendor list',
-	};
-	handleResponse({ promise: resultPromise, res, next, ...toast });
+
+	try {
+		const data = await resultPromise;
+		const toast = {
+			status: 200,
+			type: 'select',
+			message: 'vendors',
+		};
+		return await res.status(200).json({ toast, data });
+	} catch (error) {
+		await handleError({ error, res });
+	}
 }
 
 export async function select(req, res, next) {

--- a/src/db/report/query/query.js
+++ b/src/db/report/query/query.js
@@ -2,7 +2,6 @@ import { and, eq, min, sql, sum } from 'drizzle-orm';
 import { alias } from 'drizzle-orm/pg-core';
 import {
 	handleError,
-	handleResponse,
 	validateRequest,
 } from '../../../util/index.js';
 import db from '../../index.js';

--- a/src/db/slider/query/coloring_transaction.js
+++ b/src/db/slider/query/coloring_transaction.js
@@ -1,7 +1,6 @@
 import { desc, eq } from 'drizzle-orm';
 import {
 	handleError,
-	handleResponse,
 	validateRequest,
 } from '../../../util/index.js';
 import * as hrSchema from '../../hr/schema.js';
@@ -100,12 +99,17 @@ export async function selectAll(req, res, next) {
 		)
 		.orderBy(desc(coloring_transaction.created_at));
 
-	const toast = {
-		status: 200,
-		type: 'select_all',
-		message: 'coloring_transaction list',
-	};
-	handleResponse({ promise: resultPromise, res, next, ...toast });
+	try {
+		const data = await resultPromise;
+		const toast = {
+			status: 200,
+			type: 'select_all',
+			message: 'All coloring_transactions list',
+		};
+		return await res.status(200).json({ toast, data });
+	} catch (error) {
+		await handleError({ error, res });
+	}
 }
 
 export async function select(req, res, next) {

--- a/src/db/slider/query/die_casting.js
+++ b/src/db/slider/query/die_casting.js
@@ -2,7 +2,6 @@ import { and, desc, eq, or, sql } from 'drizzle-orm';
 import { alias } from 'drizzle-orm/pg-core';
 import {
 	handleError,
-	handleResponse,
 	validateRequest,
 } from '../../../util/index.js';
 import * as hrSchema from '../../hr/schema.js';
@@ -194,13 +193,17 @@ export async function selectAll(req, res, next) {
 		)
 		.orderBy(desc(die_casting.created_at));
 
-	const toast = {
-		status: 200,
-		type: 'select_all',
-		message: 'Die Casting list',
-	};
-
-	handleResponse({ promise: resultPromise, res, next, ...toast });
+	try {
+		const data = await resultPromise;
+		const toast = {
+			status: 200,
+			type: 'select_all',
+			message: 'All die_casting list',
+		};
+		return await res.status(200).json({ toast, data });
+	} catch (error) {
+		await handleError({ error, res });
+	}
 }
 
 export async function select(req, res, next) {

--- a/src/db/slider/query/die_casting_production.js
+++ b/src/db/slider/query/die_casting_production.js
@@ -1,7 +1,6 @@
 import { eq, sql } from 'drizzle-orm';
 import {
 	handleError,
-	handleResponse,
 	validateRequest,
 } from '../../../util/index.js';
 import * as hrSchema from '../../hr/schema.js';

--- a/src/db/slider/query/die_casting_to_assembly_stock.js
+++ b/src/db/slider/query/die_casting_to_assembly_stock.js
@@ -2,7 +2,6 @@ import { desc, eq, sql } from 'drizzle-orm';
 import { alias } from 'drizzle-orm/pg-core';
 import {
 	handleError,
-	handleResponse,
 	validateRequest,
 } from '../../../util/index.js';
 import * as hrSchema from '../../hr/schema.js';

--- a/src/db/slider/query/die_casting_transaction.js
+++ b/src/db/slider/query/die_casting_transaction.js
@@ -2,7 +2,6 @@ import { and, eq, sql } from 'drizzle-orm';
 import { createApi } from '../../../util/api.js';
 import {
 	handleError,
-	handleResponse,
 	validateRequest,
 } from '../../../util/index.js';
 import * as hrSchema from '../../hr/schema.js';

--- a/src/db/slider/query/production.js
+++ b/src/db/slider/query/production.js
@@ -2,7 +2,6 @@ import { eq, sql } from 'drizzle-orm';
 import { alias } from 'drizzle-orm/pg-core';
 import {
 	handleError,
-	handleResponse,
 	validateRequest,
 } from '../../../util/index.js';
 import db from '../../index.js';

--- a/src/db/slider/query/stock.js
+++ b/src/db/slider/query/stock.js
@@ -2,7 +2,6 @@ import { eq, sql } from 'drizzle-orm';
 import { alias } from 'drizzle-orm/pg-core';
 import {
 	handleError,
-	handleResponse,
 	validateRequest,
 } from '../../../util/index.js';
 import db from '../../index.js';

--- a/src/db/slider/query/transaction.js
+++ b/src/db/slider/query/transaction.js
@@ -1,7 +1,6 @@
 import { eq, sql } from 'drizzle-orm';
 import {
 	handleError,
-	handleResponse,
 	validateRequest,
 } from '../../../util/index.js';
 import * as hrSchema from '../../hr/schema.js';

--- a/src/db/slider/query/trx_against_stock.js
+++ b/src/db/slider/query/trx_against_stock.js
@@ -2,7 +2,6 @@ import { eq, sql } from 'drizzle-orm';
 import { alias } from 'drizzle-orm/pg-core';
 import {
 	handleError,
-	handleResponse,
 	validateRequest,
 } from '../../../util/index.js';
 import * as hrSchema from '../../hr/schema.js';

--- a/src/db/thread/query/batch.js
+++ b/src/db/thread/query/batch.js
@@ -3,7 +3,6 @@ import { alias } from 'drizzle-orm/pg-core';
 import { createApi } from '../../../util/api.js';
 import {
 	handleError,
-	handleResponse,
 	validateRequest,
 } from '../../../util/index.js';
 import * as hrSchema from '../../hr/schema.js';

--- a/src/db/thread/query/batch_entry.js
+++ b/src/db/thread/query/batch_entry.js
@@ -1,7 +1,6 @@
 import { desc, eq, sql } from 'drizzle-orm';
 import {
 	handleError,
-	handleResponse,
 	validateRequest,
 } from '../../../util/index.js';
 import db from '../../index.js';
@@ -185,12 +184,18 @@ export async function selectAll(req, res, next) {
 			eq(batch_entry.order_entry_uuid, order_entry.uuid)
 		)
 		.orderBy(desc(batch_entry.created_at));
-	const toast = {
-		status: 201,
-		type: 'select_all',
-		message: 'batch_entry list',
-	};
-	handleResponse({ promise: resultPromise, res, next, ...toast });
+
+	try {
+		const data = await resultPromise;
+		const toast = {
+			status: 200,
+			type: 'select_all',
+			message: 'batch_entry list',
+		};
+		return await res.status(200).json({ toast, data });
+	} catch (error) {
+		await handleError({ error, res });
+	}
 }
 
 export async function select(req, res, next) {

--- a/src/db/thread/query/batch_entry_production.js
+++ b/src/db/thread/query/batch_entry_production.js
@@ -1,7 +1,6 @@
 import { desc, eq, sql } from 'drizzle-orm';
 import {
 	handleError,
-	handleResponse,
 	validateRequest,
 } from '../../../util/index.js';
 
@@ -103,13 +102,17 @@ export async function selectAll(req, res, next) {
 		)
 		.orderBy(desc(batch_entry_production.created_at));
 
-	const toast = {
-		status: 200,
-		type: 'select all',
-		message: 'batch_entry_production list',
-	};
-
-	handleResponse({ promise: resultPromise, res, next, ...toast });
+	try {
+		const data = await resultPromise;
+		const toast = {
+			status: 200,
+			type: 'select_all',
+			message: 'batch_entry_production list',
+		};
+		return await res.status(200).json({ toast, data });
+	} catch (error) {
+		await handleError({ error, res });
+	}
 }
 
 export async function select(req, res, next) {

--- a/src/db/thread/query/batch_entry_trx.js
+++ b/src/db/thread/query/batch_entry_trx.js
@@ -1,7 +1,6 @@
 import { desc, eq, sql } from 'drizzle-orm';
 import {
 	handleError,
-	handleResponse,
 	validateRequest,
 } from '../../../util/index.js';
 
@@ -98,13 +97,19 @@ export async function selectAll(req, res, next) {
 		)
 		.orderBy(desc(batch_entry_trx.created_at));
 
-	const toast = {
-		status: 200,
-		type: 'select all',
-		message: 'batch_entry_trx list',
-	};
+	try {
+		const data = await resultPromise;
 
-	handleResponse({ promise: resultPromise, res, next, ...toast });
+		const toast = {
+			status: 200,
+			type: 'select',
+			message: 'batch_entry_trx list',
+		};
+
+		return await res.status(200).json({ toast, data });
+	} catch (error) {
+		await handleError({ error, res });
+	}
 }
 
 export async function select(req, res, next) {

--- a/src/db/thread/query/challan.js
+++ b/src/db/thread/query/challan.js
@@ -3,7 +3,6 @@ import { alias } from 'drizzle-orm/pg-core';
 import { createApi } from '../../../util/api.js';
 import {
 	handleError,
-	handleResponse,
 	validateRequest,
 } from '../../../util/index.js';
 import * as hrSchema from '../../hr/schema.js';

--- a/src/db/thread/query/challan_entry.js
+++ b/src/db/thread/query/challan_entry.js
@@ -1,7 +1,6 @@
 import { asc, desc, eq, sql } from 'drizzle-orm';
 import {
 	handleError,
-	handleResponse,
 	validateRequest,
 } from '../../../util/index.js';
 import * as hrSchema from '../../hr/schema.js';
@@ -98,13 +97,17 @@ export async function selectAll(req, res, next) {
 		)
 		.orderBy(desc(challan_entry.created_at));
 
-	const toast = {
-		status: 200,
-		type: 'select all',
-		message: 'challan_entry list',
-	};
-
-	handleResponse({ promise: resultPromise, res, next, ...toast });
+	try {
+		const data = await resultPromise;
+		const toast = {
+			status: 200,
+			type: 'select_all',
+			message: 'challan_entry list',
+		};
+		return await res.status(200).json({ toast, data });
+	} catch (error) {
+		await handleError({ error, res });
+	}
 }
 
 export async function select(req, res, next) {

--- a/src/db/thread/query/count_length.js
+++ b/src/db/thread/query/count_length.js
@@ -2,7 +2,6 @@ import { asc, eq, sql } from 'drizzle-orm';
 import { createApi } from '../../../util/api.js';
 import {
 	handleError,
-	handleResponse,
 	validateRequest,
 } from '../../../util/index.js';
 import * as hrSchema from '../../hr/schema.js';
@@ -108,13 +107,18 @@ export async function selectAll(req, res, next) {
 		)
 		.orderBy(asc(count_length.count), asc(count_length.length));
 
-	const toast = {
-		status: 200,
-		type: 'select_all',
-		message: 'count_length list',
-	};
+	try {
+		const data = await resultPromise;
+		const toast = {
+			status: 200,
+			type: 'select',
+			message: 'count_length list',
+		};
 
-	handleResponse({ promise: resultPromise, res, next, ...toast });
+		return await res.status(200).json({ toast, data });
+	} catch (error) {
+		await handleError({ error, res });
+	}
 }
 
 export async function select(req, res, next) {

--- a/src/db/thread/query/dyes_category.js
+++ b/src/db/thread/query/dyes_category.js
@@ -2,7 +2,6 @@ import { asc, desc, eq, sql } from 'drizzle-orm';
 import { createApi } from '../../../util/api.js';
 import {
 	handleError,
-	handleResponse,
 	validateRequest,
 } from '../../../util/index.js';
 import * as hrSchema from '../../hr/schema.js';
@@ -102,12 +101,18 @@ export async function selectAll(req, res, next) {
 		)
 		.orderBy(asc(dyes_category.id));
 
-	const toast = {
-		status: 200,
-		type: 'select_all',
-		message: 'dyes_category list',
-	};
-	handleResponse({ promise: resultPromise, res, next, ...toast });
+	try {
+		const data = await resultPromise;
+		const toast = {
+			status: 200,
+			type: 'select_all',
+			message: 'dyes_category list',
+		};
+
+		return await res.status(200).json({ toast, data });
+	} catch (error) {
+		await handleError({ error, res });
+	}
 }
 
 export async function select(req, res, next) {

--- a/src/db/thread/query/order_entry.js
+++ b/src/db/thread/query/order_entry.js
@@ -2,7 +2,6 @@ import { asc, desc, eq, sql } from 'drizzle-orm';
 import { createApi } from '../../../util/api.js';
 import {
 	handleError,
-	handleResponse,
 	validateRequest,
 } from '../../../util/index.js';
 import * as hrSchema from '../../hr/schema.js';
@@ -143,13 +142,18 @@ export async function selectAll(req, res, next) {
 		)
 		.orderBy(asc(order_entry.created_at));
 
-	const toast = {
-		status: 200,
-		type: 'select_all',
-		message: 'order_entry list',
-	};
+	try {
+		const data = await resultPromise;
+		const toast = {
+			status: 200,
+			type: 'select',
+			message: 'order_entry list',
+		};
 
-	handleResponse({ promise: resultPromise, res, next, ...toast });
+		return await res.status(200).json({ toast, data });
+	} catch (error) {
+		await handleError({ error, res });
+	}
 }
 
 export async function select(req, res, next) {
@@ -277,11 +281,16 @@ export async function selectOrderEntryByOrderInfoUuid(req, res, next) {
 		)
 		.where(eq(order_entry.order_info_uuid, req.params.order_info_uuid));
 
-	const toast = {
-		status: 200,
-		type: 'select',
-		message: 'order_entry detail',
-	};
+	try {
+		const data = await resultPromise;
+		const toast = {
+			status: 200,
+			type: 'select',
+			message: 'order_entry list',
+		};
 
-	handleResponse({ promise: resultPromise, res, next, ...toast });
+		return await res.status(200).json({ toast, data });
+	} catch (error) {
+		await handleError({ error, res });
+	}
 }

--- a/src/db/thread/query/order_entry_v2.js
+++ b/src/db/thread/query/order_entry_v2.js
@@ -2,7 +2,6 @@ import { asc, desc, eq, sql } from 'drizzle-orm';
 import { createApi } from '../../../util/api.js';
 import {
 	handleError,
-	handleResponse,
 	validateRequest,
 } from '../../../util/index.js';
 import * as hrSchema from '../../hr/schema.js';
@@ -143,13 +142,17 @@ export async function selectAll(req, res, next) {
 		)
 		.orderBy(asc(order_entry.created_at));
 
-	const toast = {
-		status: 200,
-		type: 'select_all',
-		message: 'order_entry list',
-	};
-
-	handleResponse({ promise: resultPromise, res, next, ...toast });
+	try {
+		const data = await resultPromise;
+		const toast = {
+			status: 200,
+			type: 'select_all',
+			message: 'order_entry list',
+		};
+		return await res.status(200).json({ toast, data });
+	} catch (error) {
+		await handleError({ error, res });
+	}
 }
 
 export async function select(req, res, next) {
@@ -277,11 +280,15 @@ export async function selectOrderEntryByOrderInfoUuid(req, res, next) {
 		)
 		.where(eq(order_entry.order_info_uuid, req.params.order_info_uuid));
 
-	const toast = {
-		status: 200,
-		type: 'select',
-		message: 'order_entry detail',
-	};
-
-	handleResponse({ promise: resultPromise, res, next, ...toast });
+	try {
+		const data = await resultPromise;
+		const toast = {
+			status: 200,
+			type: 'select',
+			message: 'order_entry list',
+		};
+		return await res.status(200).json({ toast, data });
+	} catch (error) {
+		await handleError({ error, res });
+	}
 }

--- a/src/db/thread/query/order_info.js
+++ b/src/db/thread/query/order_info.js
@@ -2,7 +2,6 @@ import { asc, desc, eq, sql } from 'drizzle-orm';
 import { createApi } from '../../../util/api.js';
 import {
 	handleError,
-	handleResponse,
 	validateRequest,
 } from '../../../util/index.js';
 import * as hrSchema from '../../hr/schema.js';

--- a/src/db/thread/query/order_info_v2.js
+++ b/src/db/thread/query/order_info_v2.js
@@ -2,7 +2,6 @@ import { asc, desc, eq, sql } from 'drizzle-orm';
 import { createApi } from '../../../util/api.js';
 import {
 	handleError,
-	handleResponse,
 	validateRequest,
 } from '../../../util/index.js';
 import * as hrSchema from '../../hr/schema.js';

--- a/src/db/thread/query/programs.js
+++ b/src/db/thread/query/programs.js
@@ -2,7 +2,6 @@ import { asc, eq, sql } from 'drizzle-orm';
 import { createApi } from '../../../util/api.js';
 import {
 	handleError,
-	handleResponse,
 	validateRequest,
 } from '../../../util/index.js';
 import * as hrSchema from '../../hr/schema.js';
@@ -111,13 +110,19 @@ export async function selectAll(req, res, next) {
 		.leftJoin(hrSchema.users, eq(programs.created_by, hrSchema.users.uuid))
 		.orderBy(asc(dyes_category.id));
 
-	const toast = {
-		status: 200,
-		type: 'select_all',
-		message: 'programs list',
-	};
+	try {
+		const data = await resultPromise;
 
-	handleResponse({ promise: resultPromise, res, next, ...toast });
+		const toast = {
+			status: 200,
+			type: 'select',
+			message: 'programs list',
+		};
+
+		return await res.status(200).json({ toast, data });
+	} catch (error) {
+		await handleError({ error, res });
+	}
 }
 
 export async function select(req, res, next) {

--- a/src/db/zipper/query/dyed_tape_transaction_from_stock.js
+++ b/src/db/zipper/query/dyed_tape_transaction_from_stock.js
@@ -3,7 +3,6 @@ import { alias } from 'drizzle-orm/pg-core';
 import { createApi } from '../../../util/api.js';
 import {
 	handleError,
-	handleResponse,
 	validateRequest,
 } from '../../../util/index.js';
 import * as hrSchema from '../../hr/schema.js';

--- a/src/db/zipper/query/dyeing_batch.js
+++ b/src/db/zipper/query/dyeing_batch.js
@@ -2,7 +2,6 @@ import { desc, eq, sql } from 'drizzle-orm';
 import { createApi } from '../../../util/api.js';
 import {
 	handleError,
-	handleResponse,
 	validateRequest,
 } from '../../../util/index.js';
 import * as hrSchema from '../../hr/schema.js';

--- a/src/db/zipper/query/dyeing_batch_entry.js
+++ b/src/db/zipper/query/dyeing_batch_entry.js
@@ -1,7 +1,6 @@
 import { desc, eq, sql } from 'drizzle-orm';
 import {
 	handleError,
-	handleResponse,
 	validateRequest,
 } from '../../../util/index.js';
 import db from '../../index.js';

--- a/src/db/zipper/query/dyeing_batch_production.js
+++ b/src/db/zipper/query/dyeing_batch_production.js
@@ -1,7 +1,6 @@
 import { desc, eq, sql } from 'drizzle-orm';
 import {
 	handleError,
-	handleResponse,
 	validateRequest,
 } from '../../../util/index.js';
 import * as hrSchema from '../../hr/schema.js';
@@ -101,18 +100,19 @@ export async function selectAll(req, res, next) {
 			eq(dyeing_batch_production.created_by, hrSchema.users.uuid)
 		)
 		.orderBy(desc(dyeing_batch_production.created_at));
-	const toast = {
-		status: 200,
-		type: 'select_all',
-		message: 'dyeing_batch_production list',
-	};
 
-	handleResponse({
-		promise: resultPromise,
-		res,
-		next,
-		...toast,
-	});
+	try {
+		const data = await resultPromise;
+		const toast = {
+			status: 200,
+			type: 'select_all',
+			message: 'dyeing_batch_production list',
+		};
+
+		return await res.status(200).json({ toast, data });
+	} catch (error) {
+		await handleError({ error, res });
+	}
 }
 
 export async function select(req, res, next) {

--- a/src/db/zipper/query/finishing_batch.js
+++ b/src/db/zipper/query/finishing_batch.js
@@ -2,7 +2,6 @@ import { desc, eq, sql } from 'drizzle-orm';
 import { createApi } from '../../../util/api.js';
 import {
 	handleError,
-	handleResponse,
 	validateRequest,
 } from '../../../util/index.js';
 import * as hrSchema from '../../hr/schema.js';

--- a/src/db/zipper/query/finishing_batch_entry.js
+++ b/src/db/zipper/query/finishing_batch_entry.js
@@ -1,7 +1,6 @@
 import { desc, eq, sql } from 'drizzle-orm';
 import {
 	handleError,
-	handleResponse,
 	validateRequest,
 } from '../../../util/index.js';
 import * as hrSchema from '../../hr/schema.js';
@@ -113,18 +112,19 @@ export async function selectAll(req, res, next) {
 			eq(hrSchema.users.uuid, finishing_batch_entry.created_by)
 		);
 
-	const toast = {
-		status: 200,
-		type: 'select_all',
-		message: 'finishing_batch_entry list',
-	};
+	try {
+		const data = await finishingBatchEntryPromise;
 
-	handleResponse({
-		promise: finishingBatchEntryPromise,
-		res,
-		next,
-		...toast,
-	});
+		const toast = {
+			status: 200,
+			type: 'select',
+			message: 'finishing_batch_entry list',
+		};
+
+		return await res.status(200).json({ toast, data });
+	} catch (error) {
+		await handleError({ error, res });
+	}
 }
 
 export async function select(req, res, next) {

--- a/src/db/zipper/query/finishing_batch_production.js
+++ b/src/db/zipper/query/finishing_batch_production.js
@@ -1,7 +1,6 @@
 import { desc, eq, sql } from 'drizzle-orm';
 import {
 	handleError,
-	handleResponse,
 	validateRequest,
 } from '../../../util/index.js';
 import * as hrSchema from '../../hr/schema.js';
@@ -154,17 +153,18 @@ export async function selectAll(req, res, next) {
 		)
 		.orderBy(desc(finishing_batch_production.created_at));
 
-	const toast = {
-		status: 200,
-		type: 'select_all',
-		message: 'Finishing Batch Production list',
-	};
-	handleResponse({
-		promise: resultPromise,
-		res,
-		next,
-		...toast,
-	});
+	try {
+		const data = await resultPromise;
+		const toast = {
+			status: 200,
+			type: 'select all',
+			message: 'Finishing Batch Production list',
+		};
+
+		return await res.status(200).json({ toast, data });
+	} catch (error) {
+		await handleError({ error, res });
+	}
 }
 
 export async function select(req, res, next) {

--- a/src/db/zipper/query/finishing_batch_transaction.js
+++ b/src/db/zipper/query/finishing_batch_transaction.js
@@ -1,7 +1,6 @@
 import { desc, eq, sql } from 'drizzle-orm';
 import {
 	handleError,
-	handleResponse,
 	validateRequest,
 } from '../../../util/index.js';
 import * as hrSchema from '../../hr/schema.js';
@@ -167,17 +166,18 @@ export async function selectAll(req, res, next) {
 		)
 		.orderBy(desc(finishing_batch_transaction.created_at));
 
-	const toast = {
-		status: 200,
-		type: 'select_all',
-		message: 'Finishing Batch Transaction list',
-	};
-	handleResponse({
-		promise: resultPromise,
-		res,
-		next,
-		...toast,
-	});
+	try {
+		const data = await resultPromise;
+		const toast = {
+			status: 200,
+			type: 'select all',
+			message: 'Finishing Batch Transaction List',
+		};
+
+		return await res.status(200).json({ toast, data });
+	} catch (error) {
+		await handleError({ error, res });
+	}
 }
 export async function select(req, res, next) {
 	if (!(await validateRequest(req, next))) return;

--- a/src/db/zipper/query/material_trx_against_order_description.js
+++ b/src/db/zipper/query/material_trx_against_order_description.js
@@ -2,7 +2,6 @@ import { eq, sql } from 'drizzle-orm';
 import { createApi } from '../../../util/api.js';
 import {
 	handleError,
-	handleResponse,
 	validateRequest,
 } from '../../../util/index.js';
 import db from '../../index.js';

--- a/src/db/zipper/query/multi_color_dashboard.js
+++ b/src/db/zipper/query/multi_color_dashboard.js
@@ -1,7 +1,6 @@
 import { desc, eq, sql } from 'drizzle-orm';
 import {
 	handleError,
-	handleResponse,
 	validateRequest,
 } from '../../../util/index.js';
 import * as hrSchema from '../../hr/schema.js';

--- a/src/db/zipper/query/multi_color_tape_receive.js
+++ b/src/db/zipper/query/multi_color_tape_receive.js
@@ -1,7 +1,6 @@
 import { desc, eq, sql } from 'drizzle-orm';
 import {
 	handleError,
-	handleResponse,
 	validateRequest,
 } from '../../../util/index.js';
 import * as hrSchema from '../../hr/schema.js';

--- a/src/db/zipper/query/order_description.js
+++ b/src/db/zipper/query/order_description.js
@@ -3,7 +3,6 @@ import { alias } from 'drizzle-orm/pg-core';
 import { createApi } from '../../../util/api.js';
 import {
 	handleError,
-	handleResponse,
 	validateRequest,
 } from '../../../util/index.js';
 import * as hrSchema from '../../hr/schema.js';
@@ -495,18 +494,18 @@ export async function selectAll(req, res, next) {
 		)
 		.orderBy(desc(order_description.created_at));
 
-	const toast = {
-		status: 200,
-		type: 'select_all',
-		message: 'Order descriptions List',
-	};
+	try {
+		const data = await orderDescriptionPromise;
+		const toast = {
+			status: 200,
+			type: 'select_all',
+			message: 'Order Description list',
+		};
 
-	handleResponse({
-		promise: orderDescriptionPromise,
-		res,
-		next,
-		...toast,
-	});
+		return await res.status(200).json({ toast, data });
+	} catch (error) {
+		await handleError({ error, res });
+	}
 }
 
 export async function select(req, res, next) {

--- a/src/db/zipper/query/order_entry.js
+++ b/src/db/zipper/query/order_entry.js
@@ -2,7 +2,6 @@ import { asc, desc, eq, sql } from 'drizzle-orm';
 import { alias } from 'drizzle-orm/pg-core';
 import {
 	handleError,
-	handleResponse,
 	validateRequest,
 } from '../../../util/index.js';
 import * as deliverySchema from '../../delivery/schema.js';
@@ -164,18 +163,18 @@ export async function selectAll(req, res, next) {
 		.from(order_entry)
 		.orderBy(desc(order_entry.created_at));
 
-	const toast = {
-		status: 200,
-		type: 'select_all',
-		message: 'Order entry list',
-	};
+	try {
+		const data = await order_entryPromise;
+		const toast = {
+			status: 200,
+			type: 'select_all',
+			message: 'Order Entry',
+		};
 
-	handleResponse({
-		promise: order_entryPromise,
-		res,
-		next,
-		...toast,
-	});
+		return await res.status(200).json({ toast, data });
+	} catch (error) {
+		await handleError({ error, res });
+	}
 }
 
 export async function select(req, res, next) {

--- a/src/db/zipper/query/order_info.js
+++ b/src/db/zipper/query/order_info.js
@@ -1,6 +1,5 @@
 import {
 	handleError,
-	handleResponse,
 	validateRequest,
 } from '../../../util/index.js';
 import db from '../../index.js';
@@ -222,18 +221,18 @@ export async function selectAll(req, res, next) {
 		)
 		.orderBy(desc(order_info.created_at));
 
-	const toast = {
-		status: 200,
-		type: 'select_all',
-		message: 'Order Info',
-	};
+	try {
+		const data = await orderInfoPromise;
+		const toast = {
+			status: 200,
+			type: 'select_all',
+			message: 'Order Info list',
+		};
 
-	handleResponse({
-		promise: orderInfoPromise,
-		res,
-		next,
-		...toast,
-	});
+		return await res.status(200).json({ toast, data });
+	} catch (error) {
+		await handleError({ error, res });
+	}
 }
 
 export async function select(req, res, next) {

--- a/src/db/zipper/query/planning.js
+++ b/src/db/zipper/query/planning.js
@@ -2,7 +2,6 @@ import { desc, eq, sql } from 'drizzle-orm';
 import { createApi } from '../../../util/api.js';
 import {
 	handleError,
-	handleResponse,
 	validateRequest,
 } from '../../../util/index.js';
 import * as hrSchema from '../../hr/schema.js';
@@ -135,13 +134,18 @@ export async function selectAll(req, res, next) {
 		.leftJoin(hrSchema.users, eq(planning.created_by, hrSchema.users.uuid))
 		.orderBy(desc(planning.created_at));
 
-	const toast = {
-		status: 200,
-		type: 'select_all',
-		message: 'planning list',
-	};
+	try {
+		const data = await resultPromise;
+		const toast = {
+			status: 200,
+			type: 'select',
+			message: 'planning list',
+		};
 
-	handleResponse({ promise: resultPromise, res, next, ...toast });
+		return await res.status(200).json({ toast, data });
+	} catch (error) {
+		await handleError({ error, res });
+	}
 }
 
 export async function select(req, res, next) {
@@ -188,13 +192,18 @@ export async function selectPlanningByPlanningWeek(req, res, next) {
 		.leftJoin(hrSchema.users, eq(planning.created_by, hrSchema.users.uuid))
 		.where(eq(planning.week, req.params.planning_week));
 
-	const toast = {
-		status: 200,
-		type: 'select',
-		message: 'planning',
-	};
+	try {
+		const data = await resultPromise;
+		const toast = {
+			status: 200,
+			type: 'select',
+			message: 'planning by planning week',
+		};
 
-	handleResponse({ promise: resultPromise, res, next, ...toast });
+		return await res.status(200).json({ toast, data: data[0] });
+	} catch (error) {
+		await handleError({ error, res });
+	}
 }
 
 export async function selectPlanningAndPlanningEntryByPlanningWeek(

--- a/src/db/zipper/query/planning_entry.js
+++ b/src/db/zipper/query/planning_entry.js
@@ -1,7 +1,6 @@
 import { and, desc, eq, sql } from 'drizzle-orm';
 import {
 	handleError,
-	handleResponse,
 	validateRequest,
 } from '../../../util/index.js';
 import db from '../../index.js';
@@ -162,17 +161,18 @@ export async function selectAll(req, res, next) {
 		.leftJoin(planning, eq(planning.uuid, planning_entry.planning_week))
 		.orderBy(desc(planning_entry.created_at));
 
-	const toast = {
-		status: 200,
-		type: 'select_all',
-		message: 'batch entry list',
-	};
-	handleResponse({
-		promise: resultPromise,
-		res,
-		next,
-		...toast,
-	});
+	try {
+		const data = await resultPromise;
+		const toast = {
+			status: 200,
+			type: 'select_all',
+			message: 'planning_entry',
+		};
+
+		return await res.status(200).json({ toast, data });
+	} catch (error) {
+		await handleError({ error, res });
+	}
 }
 
 export async function select(req, res, next) {

--- a/src/db/zipper/query/sfg.js
+++ b/src/db/zipper/query/sfg.js
@@ -1,7 +1,6 @@
 import { and, desc, eq, sql } from 'drizzle-orm';
 import {
 	handleError,
-	handleResponse,
 	validateRequest,
 } from '../../../util/index.js';
 import db from '../../index.js';
@@ -105,12 +104,18 @@ export async function selectAll(req, res, next) {
 		.where(recipe_uuid === 'true' ? sql`sfg.recipe_uuid IS NOT NULL` : null)
 		.orderBy(desc(sfg.created_at));
 
-	const toast = {
-		status: 200,
-		type: 'select_all',
-		message: 'sfg list',
-	};
-	handleResponse({ promise: resultPromise, res, next, ...toast });
+	try {
+		const data = await resultPromise;
+		const toast = {
+			status: 200,
+			type: 'select_all',
+			message: 'sfg list',
+		};
+
+		return await res.status(200).json({ toast, data });
+	} catch (error) {
+		await handleError({ error, res });
+	}
 }
 
 export async function select(req, res, next) {

--- a/src/db/zipper/query/tape_coil.js
+++ b/src/db/zipper/query/tape_coil.js
@@ -2,7 +2,6 @@ import { and, desc, eq, or, sql } from 'drizzle-orm';
 import { alias } from 'drizzle-orm/pg-core';
 import {
 	handleError,
-	handleResponse,
 	validateRequest,
 } from '../../../util/index.js';
 import * as hrSchema from '../../hr/schema.js';
@@ -302,10 +301,15 @@ export async function selectByNylon(req, res, next) {
 		)
 		.where(eq(sql`lower(item_properties.name)`, 'nylon'));
 
-	const toast = {
-		status: 200,
-		type: 'select',
-		message: 'tape_coil',
-	};
-	handleResponse({ promise: tapeCoilPromise, res, next, ...toast });
+	try {
+		const data = await tapeCoilPromise;
+		const toast = {
+			status: 200,
+			type: 'select',
+			message: 'tape_coil by nylon',
+		};
+		return await res.status(200).json({ toast, data });
+	} catch (error) {
+		await handleError({ error, res });
+	}
 }

--- a/src/db/zipper/query/tape_coil_production.js
+++ b/src/db/zipper/query/tape_coil_production.js
@@ -2,7 +2,6 @@ import { desc, eq, sql } from 'drizzle-orm';
 import { alias } from 'drizzle-orm/pg-core';
 import {
 	handleError,
-	handleResponse,
 	validateRequest,
 } from '../../../util/index.js';
 import * as hrSchema from '../../hr/schema.js';
@@ -126,12 +125,18 @@ export async function selectAll(req, res, next) {
 		)
 		.orderBy(desc(tape_coil_production.created_at));
 
-	const toast = {
-		status: 200,
-		type: 'select_all',
-		message: 'tape_coil_production list',
-	};
-	handleResponse({ promise: resultPromise, res, next, ...toast });
+	try {
+		const data = await resultPromise;
+		const toast = {
+			status: 200,
+			type: 'select_all',
+			message: 'tape_coil_production list',
+		};
+
+		return await res.status(200).json({ toast, data });
+	} catch (error) {
+		await handleError({ error, res });
+	}
 }
 
 export async function select(req, res, next) {
@@ -245,10 +250,16 @@ export async function selectTapeCoilProductionBySection(req, res, next) {
 		.where(eq(tape_coil_production.section, req.params.section))
 		.orderBy(desc(tape_coil_production.created_at));
 
-	const toast = {
-		status: 200,
-		type: 'select_all',
-		message: `tape_coil_production of ${req.params.section}`,
-	};
-	handleResponse({ promise: tapeCoilProductionPromise, res, next, ...toast });
+	try {
+		const data = await tapeCoilProductionPromise;
+		const toast = {
+			status: 200,
+			type: 'select',
+			message: 'tape_coil_production',
+		};
+
+		return await res.status(200).json({ toast, data });
+	} catch (error) {
+		await handleError({ error, res });
+	}
 }

--- a/src/db/zipper/query/tape_coil_required.js
+++ b/src/db/zipper/query/tape_coil_required.js
@@ -2,7 +2,6 @@ import { desc, eq } from 'drizzle-orm';
 import { alias } from 'drizzle-orm/pg-core';
 import {
 	handleError,
-	handleResponse,
 	validateRequest,
 } from '../../../util/index.js';
 import * as hrSchema from '../../hr/schema.js';
@@ -132,13 +131,18 @@ export async function selectAll(req, res, next) {
 		)
 		.orderBy(desc(tape_coil_required.created_at));
 
-	const toast = {
-		status: 200,
-		type: 'select_all',
-		message: 'tape_coil_required list',
-	};
+	try {
+		const data = await tapeCoilRequiredPromise;
+		const toast = {
+			status: 200,
+			type: 'select_all',
+			message: 'tape_coil_required list',
+		};
 
-	handleResponse({ promise: tapeCoilRequiredPromise, res, next, ...toast });
+		return await res.status(200).json({ toast, data });
+	} catch (error) {
+		await handleError({ error, res });
+	}
 }
 
 export async function select(req, res, next) {

--- a/src/db/zipper/query/tape_coil_to_dyeing.js
+++ b/src/db/zipper/query/tape_coil_to_dyeing.js
@@ -1,7 +1,6 @@
 import { eq, sql } from 'drizzle-orm';
 import {
 	handleError,
-	handleResponse,
 	validateRequest,
 } from '../../../util/index.js';
 import * as hrSchema from '../../hr/schema.js';

--- a/src/db/zipper/query/tape_trx.js
+++ b/src/db/zipper/query/tape_trx.js
@@ -2,7 +2,6 @@ import { desc, eq, sql } from 'drizzle-orm';
 import { alias } from 'drizzle-orm/pg-core';
 import {
 	handleError,
-	handleResponse,
 	validateRequest,
 } from '../../../util/index.js';
 import * as hrSchema from '../../hr/schema.js';
@@ -119,12 +118,18 @@ export async function selectAll(req, res, next) {
 			eq(tape_coil.zipper_number_uuid, zipper_number_properties.uuid)
 		)
 		.orderBy(desc(tape_trx.created_at));
-	const toast = {
-		status: 200,
-		type: 'select_all',
-		message: 'tape_trx list',
-	};
-	handleResponse({ promise: resultPromise, res, next, ...toast });
+
+	try {
+		const data = await resultPromise;
+		const toast = {
+			status: 200,
+			type: 'select',
+			message: 'tape_trx list',
+		};
+		return await res.status(200).json({ toast, data });
+	} catch (error) {
+		await handleError({ error, res });
+	}
 }
 
 export async function select(req, res, next) {


### PR DESCRIPTION
Eliminate unnecessary imports of handleResponse across multiple query files to streamline the codebase. Additionally, merge updates from the main branch.