### PR TITLE
Refactor booking references from 'zipper' to 'material'

### DIFF
--- a/src/db/trigger/material_stock_after_zipper_material_trx_against_order_description.sql
+++ b/src/db/trigger/material_stock_after_zipper_material_trx_against_order_description.sql
@@ -8,7 +8,7 @@ BEGIN
     WHERE material_uuid = NEW.material_uuid;
 
     IF (NEW.booking_uuid IS NOT NULL) THEN
-        UPDATE zipper.booking
+        UPDATE material.booking
         SET
             quantity = quantity - NEW.trx_quantity,
             trx_quantity = trx_quantity + NEW.trx_quantity
@@ -46,7 +46,7 @@ BEGIN
     WHERE material_uuid = NEW.material_uuid;
 
     IF (NEW.booking_uuid IS NOT NULL) THEN
-        UPDATE zipper.booking
+        UPDATE material.booking
         SET
             quantity = quantity 
                 - NEW.trx_quantity
@@ -92,7 +92,7 @@ BEGIN
     WHERE material_uuid = OLD.material_uuid;
 
     IF (OLD.booking_uuid IS NOT NULL) THEN
-        UPDATE zipper.booking
+        UPDATE material.booking
         SET
             quantity = quantity + OLD.trx_quantity,
             trx_quantity = trx_quantity - OLD.trx_quantity


### PR DESCRIPTION
Update the booking references in the material stock trigger to ensure consistency by replacing 'zipper' with 'material'.