### PR TITLE
Add marketing team functionality to the database and API

### DIFF
--- a/src/db/public/query/marketing_team.js
+++ b/src/db/public/query/marketing_team.js
@@ -1,0 +1,147 @@
+import { desc, eq } from 'drizzle-orm';
+import { handleError, validateRequest } from '../../../util/index.js';
+import * as hrSchema from '../../hr/schema.js';
+import db from '../../index.js';
+import { decimalToNumber } from '../../variables.js';
+import { marketing_team } from '../schema.js';
+
+export async function insert(req, res, next) {
+	if (!(await validateRequest(req, next))) return;
+
+	const marketing_teamPromise = db
+		.insert(marketing_team)
+		.values(req.body)
+		.returning({ insertedName: marketing_team.name });
+
+	try {
+		const data = await marketing_teamPromise;
+		const toast = {
+			status: 201,
+			type: 'insert',
+			message: `${data[0].insertedName} inserted`,
+		};
+
+		return await res.status(201).json({ toast, data });
+	} catch (error) {
+		await handleError({
+			error,
+			res,
+		});
+	}
+}
+
+export async function update(req, res, next) {
+	if (!(await validateRequest(req, next))) return;
+
+	const marketing_teamPromise = db
+		.update(marketing_team)
+		.set(req.body)
+		.where(eq(marketing_team.uuid, req.params.uuid))
+		.returning({ updatedName: marketing_team.name });
+
+	try {
+		const data = await marketing_teamPromise;
+		const toast = {
+			status: 200,
+			type: 'update',
+			message: `${data[0].updatedName} updated`,
+		};
+
+		return await res.status(200).json({ toast, data });
+	} catch (error) {
+		await handleError({
+			error,
+			res,
+		});
+	}
+}
+
+export async function remove(req, res, next) {
+	if (!(await validateRequest(req, next))) return;
+
+	const marketing_teamPromise = db
+		.delete(marketing_team)
+		.where(eq(marketing_team.uuid, req.params.uuid))
+		.returning({ deletedName: marketing_team.name });
+
+	try {
+		const data = await marketing_teamPromise;
+		const toast = {
+			status: 200,
+			type: 'delete',
+			message: `${data[0].deletedName} deleted`,
+		};
+
+		return await res.status(200).json({ toast, data });
+	} catch (error) {
+		await handleError({
+			error,
+			res,
+		});
+	}
+}
+
+export async function select(req, res, next) {
+	const marketing_teamPromise = db
+		.select({
+			uuid: marketing_team.uuid,
+			name: marketing_team.name,
+			created_at: marketing_team.created_at,
+			updated_at: marketing_team.updated_at,
+			created_by: marketing_team.created_by,
+			created_by_name: hrSchema.users.name,
+			remarks: marketing_team.remarks,
+		})
+		.from(marketing_team)
+		.leftJoin(
+			hrSchema.users,
+			eq(marketing_team.created_by, hrSchema.users.uuid)
+		)
+		.where(eq(marketing_team.uuid, req.params.uuid));
+
+	try {
+		const data = await marketing_teamPromise;
+		const toast = {
+			status: 200,
+			message: 'marketing_team select',
+		};
+		return await res.status(200).json({ toast, data });
+	} catch (error) {
+		await handleError({
+			error,
+			res,
+		});
+	}
+}
+
+export async function selectAll(req, res, next) {
+	const marketing_teamPromise = db
+		.select({
+			uuid: marketing_team.uuid,
+			name: marketing_team.name,
+			created_at: marketing_team.created_at,
+			updated_at: marketing_team.updated_at,
+			created_by: marketing_team.created_by,
+			created_by_name: hrSchema.users.name,
+			remarks: marketing_team.remarks,
+		})
+		.from(marketing_team)
+		.leftJoin(
+			hrSchema.users,
+			eq(marketing_team.created_by, hrSchema.users.uuid)
+		);
+
+	try {
+		const data = await marketing_teamPromise;
+		const toast = {
+			status: 200,
+			message: 'marketing_team list',
+		};
+		return await res.status(200).json({ toast, data });
+	} catch (error) {
+		await handleError({
+			error,
+			res,
+		});
+	}
+}

--- a/src/db/public/query/marketing_team_entry.js
+++ b/src/db/public/query/marketing_team_entry.js
@@ -1,0 +1,170 @@
+import { desc, eq } from 'drizzle-orm';
+import { handleError, validateRequest } from '../../../util/index.js';
+import * as hrSchema from '../../hr/schema.js';
+import db from '../../index.js';
+import { decimalToNumber } from '../../variables.js';
+import { marketing_team, marketing_team_entry, marketing } from '../schema.js';
+
+export async function insert(req, res, next) {
+	if (!(await validateRequest(req, next))) return;
+
+	const marketing_team_entryPromise = db
+		.insert(marketing_team_entry)
+		.values(req.body)
+		.returning({ insertedName: marketing_team_entry.name });
+
+	try {
+		const data = await marketing_team_entryPromise;
+		const toast = {
+			status: 201,
+			type: 'insert',
+			message: `${data[0].insertedName} inserted`,
+		};
+
+		return await res.status(201).json({ toast, data });
+	} catch (error) {
+		await handleError({
+			error,
+			res,
+		});
+	}
+}
+
+export async function update(req, res, next) {
+	if (!(await validateRequest(req, next))) return;
+
+	const marketing_team_entryPromise = db
+		.update(marketing_team_entry)
+		.set(req.body)
+		.where(eq(marketing_team_entry.uuid, req.params.uuid))
+		.returning({ updatedName: marketing_team_entry.name });
+
+	try {
+		const data = await marketing_team_entryPromise;
+		const toast = {
+			status: 200,
+			type: 'update',
+			message: `${data[0].updatedName} updated`,
+		};
+
+		return await res.status(200).json({ toast, data });
+	} catch (error) {
+		await handleError({
+			error,
+			res,
+		});
+	}
+}
+
+export async function remove(req, res, next) {
+	if (!(await validateRequest(req, next))) return;
+
+	const marketing_team_entryPromise = db
+		.delete(marketing_team_entry)
+		.where(eq(marketing_team_entry.uuid, req.params.uuid));
+
+	try {
+		const data = await marketing_team_entryPromise;
+		const toast = {
+			status: 200,
+			type: 'delete',
+			message: `${data[0].deletedName} deleted`,
+		};
+
+		return await res.status(200).json({ toast, data });
+	} catch (error) {
+		await handleError({
+			error,
+			res,
+		});
+	}
+}
+
+export async function select(req, res, next) {
+	const marketing_team_entryPromise = db
+		.select({
+			uuid: marketing_team_entry.uuid,
+			marketing_team_uuid: marketing_team_entry.marketing_team_uuid,
+			marketing_team_name: marketing_team.name,
+			marketing_uuid: marketing_team_entry.marketing_uuid,
+			marketing_name: marketing.name,
+			is_team_leader: marketing_team_entry.is_team_leader,
+			created_at: marketing_team_entry.created_at,
+			updated_at: marketing_team_entry.updated_at,
+			created_by: marketing_team_entry.created_by,
+			created_by_name: hrSchema.users.name,
+			remarks: marketing_team_entry.remarks,
+		})
+		.from(marketing_team_entry)
+		.leftJoin(
+			marketing_team,
+			eq(marketing_team.uuid, marketing_team_entry.marketing_team_uuid)
+		)
+		.leftJoin(
+			marketing,
+			eq(marketing.uuid, marketing_team_entry.marketing_uuid)
+		)
+		.leftJoin(
+			hrSchema.users,
+			eq(marketing_team_entry.created_by, hrSchema.users.uuid)
+		)
+		.where(eq(marketing_team_entry.uuid, req.params.uuid));
+
+	try {
+		const data = await marketing_team_entryPromise;
+		const toast = {
+			status: 200,
+			message: 'marketing_team_entry select',
+		};
+		return await res.status(200).json({ toast, data });
+	} catch (error) {
+		await handleError({
+			error,
+			res,
+		});
+	}
+}
+
+export async function selectAll(req, res, next) {
+	const marketing_team_entryPromise = db
+		.select({
+			uuid: marketing_team_entry.uuid,
+			marketing_team_uuid: marketing_team_entry.marketing_team_uuid,
+			marketing_team_name: marketing_team.name,
+			marketing_uuid: marketing_team_entry.marketing_uuid,
+			marketing_name: marketing.name,
+			is_team_leader: marketing_team_entry.is_team_leader,
+			created_at: marketing_team_entry.created_at,
+			updated_at: marketing_team_entry.updated_at,
+			created_by: marketing_team_entry.created_by,
+			created_by_name: hrSchema.users.name,
+			remarks: marketing_team_entry.remarks,
+		})
+		.from(marketing_team_entry)
+		.leftJoin(
+			marketing_team,
+			eq(marketing_team.uuid, marketing_team_entry.marketing_team_uuid)
+		)
+		.leftJoin(
+			marketing,
+			eq(marketing.uuid, marketing_team_entry.marketing_uuid)
+		)
+		.leftJoin(
+			hrSchema.users,
+			eq(marketing_team_entry.created_by, hrSchema.users.uuid)
+		);
+
+	try {
+		const data = await marketing_team_entryPromise;
+		const toast = {
+			status: 200,
+			message: 'marketing_team_entry list',
+		};
+		return await res.status(200).json({ toast, data });
+	} catch (error) {
+		await handleError({
+			error,
+			res,
+		});
+	}
+}

--- a/src/db/public/query/marketing_team_member_target.js
+++ b/src/db/public/query/marketing_team_member_target.js
@@ -1,0 +1,163 @@
+import { desc, eq } from 'drizzle-orm';
+import { handleError, validateRequest } from '../../../util/index.js';
+import * as hrSchema from '../../hr/schema.js';
+import db from '../../index.js';
+import { decimalToNumber } from '../../variables.js';
+import { marketing, marketing_team_member_target } from '../schema.js';
+
+export async function insert(req, res, next) {
+	if (!(await validateRequest(req, next))) return;
+
+	const marketing_team_member_targetPromise = db
+		.insert(marketing_team_member_target)
+		.values(req.body)
+		.returning({ insertedName: marketing_team_member_target.name });
+
+	try {
+		const data = await marketing_team_member_targetPromise;
+		const toast = {
+			status: 201,
+			type: 'insert',
+			message: `${data[0].insertedName} inserted`,
+		};
+
+		return await res.status(201).json({ toast, data });
+	} catch (error) {
+		await handleError({
+			error,
+			res,
+		});
+	}
+}
+
+export async function update(req, res, next) {
+	if (!(await validateRequest(req, next))) return;
+
+	const marketing_team_member_targetPromise = db
+		.update(marketing_team_member_target)
+		.set(req.body)
+		.where(eq(marketing_team_member_target.uuid, req.params.uuid))
+		.returning({ updatedName: marketing_team_member_target.name });
+
+	try {
+		const data = await marketing_team_member_targetPromise;
+		const toast = {
+			status: 200,
+			type: 'update',
+			message: `${data[0].updatedName} updated`,
+		};
+
+		return await res.status(200).json({ toast, data });
+	} catch (error) {
+		await handleError({
+			error,
+			res,
+		});
+	}
+}
+
+export async function remove(req, res, next) {
+	if (!(await validateRequest(req, next))) return;
+
+	const marketing_team_member_targetPromise = db
+		.delete(marketing_team_member_target)
+		.where(eq(marketing_team_member_target.uuid, req.params.uuid));
+
+	try {
+		const data = await marketing_team_member_targetPromise;
+		return await res.status(200).json({
+			toast: {
+				status: 200,
+				type: 'delete',
+				message: `${data[0].deletedName} deleted`,
+			},
+			data,
+		});
+	} catch (error) {
+		await handleError({
+			error,
+			res,
+		});
+	}
+}
+
+export async function select(req, res, next) {
+	const marketing_team_member_targetPromise = db
+		.select({
+			uuid: marketing_team_member_target.uuid,
+			marketing_uuid: marketing_team_member_target.marketing_uuid,
+			marketing_name: marketing.name,
+			year: marketing_team_member_target.year,
+			month: marketing_team_member_target.month,
+			amount: decimalToNumber(marketing_team_member_target.amount),
+			created_at: marketing_team_member_target.created_at,
+			updated_at: marketing_team_member_target.updated_at,
+			created_by: marketing_team_member_target.created_by,
+			created_by_name: hrSchema.users.name,
+			remarks: marketing_team_member_target.remarks,
+		})
+		.from(marketing_team_member_target)
+		.leftJoin(
+			marketing,
+			eq(marketing.uuid, marketing_team_member_target.marketing_uuid)
+		)
+		.leftJoin(
+			hrSchema.users,
+			eq(marketing_team_member_target.created_by, hrSchema.users.uuid)
+		)
+		.where(eq(marketing_team_member_target.uuid, req.params.uuid));
+
+	try {
+		const data = await marketing_team_member_targetPromise;
+		const toast = {
+			status: 200,
+			message: 'marketing_team_member_target select',
+		};
+		return await res.status(200).json({ toast, data });
+	} catch (error) {
+		await handleError({
+			error,
+			res,
+		});
+	}
+}
+
+export async function selectAll(req, res, next) {
+	const marketing_team_member_targetPromise = db
+		.select({
+			uuid: marketing_team_member_target.uuid,
+			marketing_uuid: marketing_team_member_target.marketing_uuid,
+			marketing_name: marketing.name,
+			year: marketing_team_member_target.year,
+			month: marketing_team_member_target.month,
+			amount: decimalToNumber(marketing_team_member_target.amount),
+			created_at: marketing_team_member_target.created_at,
+			updated_at: marketing_team_member_target.updated_at,
+			created_by: marketing_team_member_target.created_by,
+			created_by_name: hrSchema.users.name,
+			remarks: marketing_team_member_target.remarks,
+		})
+		.from(marketing_team_member_target)
+		.leftJoin(
+			marketing,
+			eq(marketing.uuid, marketing_team_member_target.marketing_uuid)
+		)
+		.leftJoin(
+			hrSchema.users,
+			eq(marketing_team_member_target.created_by, hrSchema.users.uuid)
+		);
+
+	try {
+		const data = await marketing_team_member_targetPromise;
+		const toast = {
+			status: 200,
+			message: 'marketing_team_member_target list',
+		};
+		return await res.status(200).json({ toast, data });
+	} catch (error) {
+		await handleError({
+			error,
+			res,
+		});
+	}
+}

--- a/src/db/public/route.js
+++ b/src/db/public/route.js
@@ -7,6 +7,9 @@ import * as merchandiserOperations from './query/merchandiser.js';
 import * as partyOperations from './query/party.js';
 import * as propertiesOperations from './query/properties.js';
 import * as sectionOperations from './query/section.js';
+import * as marketingTeamOperations from './query/marketing_team.js';
+import * as marketingTeamMemberTargetOperations from './query/marketing_team_member_target.js';
+import * as marketingTeamEntryOperations from './query/marketing_team_entry.js';
 
 const publicRouter = Router();
 
@@ -113,5 +116,53 @@ publicRouter.get('/machine/:uuid', machineOperations.select);
 publicRouter.post('/machine', machineOperations.insert);
 publicRouter.put('/machine/:uuid', machineOperations.update);
 publicRouter.delete('/machine/:uuid', machineOperations.remove);
+
+// marketing_team routes
+publicRouter.get('/marketing-team', marketingTeamOperations.selectAll);
+publicRouter.get('/marketing-team/:uuid', marketingTeamOperations.select);
+publicRouter.post('/marketing-team', marketingTeamOperations.insert);
+publicRouter.put('/marketing-team/:uuid', marketingTeamOperations.update);
+publicRouter.delete('/marketing-team/:uuid', marketingTeamOperations.remove);
+
+// marketing_team_member_target routes
+publicRouter.get(
+	'/marketing-team-member-target',
+	marketingTeamMemberTargetOperations.selectAll
+);
+publicRouter.get(
+	'/marketing-team-member-target/:uuid',
+	marketingTeamMemberTargetOperations.select
+);
+publicRouter.post(
+	'/marketing-team-member-target',
+	marketingTeamMemberTargetOperations.insert
+);
+publicRouter.put(
+	'/marketing-team-member-target/:uuid',
+	marketingTeamMemberTargetOperations.update
+);
+publicRouter.delete(
+	'/marketing-team-member-target/:uuid',
+	marketingTeamMemberTargetOperations.remove
+);
+
+// marketing_team_entry routes
+publicRouter.get(
+	'/marketing-team-entry',
+	marketingTeamEntryOperations.selectAll
+);
+publicRouter.get(
+	'/marketing-team-entry/:uuid',
+	marketingTeamEntryOperations.select
+);
+publicRouter.post('/marketing-team-entry', marketingTeamEntryOperations.insert);
+publicRouter.put(
+	'/marketing-team-entry/:uuid',
+	marketingTeamEntryOperations.update
+);
+publicRouter.delete(
+	'/marketing-team-entry/:uuid',
+	marketingTeamEntryOperations.remove
+);
 
 export { publicRouter };

--- a/src/db/public/schema.js
+++ b/src/db/public/schema.js
@@ -1,4 +1,4 @@
-import { integer, pgTable, text } from 'drizzle-orm/pg-core';
+import { boolean, integer, pgTable, text } from 'drizzle-orm/pg-core';
 import {
 	DateTime,
 	defaultUUID,
@@ -104,5 +104,48 @@ export const machine = pgTable('machine', {
 	updated_at: DateTime('updated_at').default(null),
 	remarks: text('remarks').default(null),
 });
+
+export const marketing_team = pgTable('marketing_team', {
+	uuid: uuid_primary,
+	name: text('name').notNull().unique(),
+	created_at: DateTime('created_at').notNull(),
+	updated_at: DateTime('updated_at').default(null),
+	created_by: defaultUUID('created_by').references(() => hrSchema.users.uuid),
+	remarks: text('remarks').default(null),
+});
+
+export const marketing_team_entry = pgTable('marketing_team_entry', {
+	uuid: uuid_primary,
+	marketing_team_uuid: defaultUUID('marketing_team_uuid').references(
+		() => marketing_team.uuid
+	),
+	marketing_uuid: defaultUUID('marketing_uuid').references(
+		() => marketing.uuid
+	),
+	is_team_leader: boolean('is_team_leader').default(false),
+	created_at: DateTime('created_at').notNull(),
+	updated_at: DateTime('updated_at').default(null),
+	created_by: defaultUUID('created_by').references(() => hrSchema.users.uuid),
+	remarks: text('remarks').default(null),
+});
+
+export const marketing_team_member_target = pgTable(
+	'marketing_team_member_target',
+	{
+		uuid: uuid_primary,
+		marketing_uuid: defaultUUID('marketing_uuid').references(
+			() => marketing.uuid
+		),
+		year: integer('year').notNull(),
+		month: integer('month').notNull(),
+		amount: PG_DECIMAL('amount').notNull(),
+		created_at: DateTime('created_at').notNull(),
+		updated_at: DateTime('updated_at').default(null),
+		created_by: defaultUUID('created_by').references(
+			() => hrSchema.users.uuid
+		),
+		remarks: text('remarks').default(null),
+	}
+);
 
 export default buyer;

--- a/src/db/public/swagger/def.js
+++ b/src/db/public/swagger/def.js
@@ -177,6 +177,59 @@ export const defMachine = {
 	},
 };
 
+export const defMarketingTeam = SED({
+	required: ['uuid', 'name', 'created_at', 'created_by'],
+	properties: {
+		uuid: SE.uuid(),
+		name: SE.string('John Doe'),
+		created_at: SE.date_time(),
+		updated_at: SE.date_time(),
+		created_by: SE.uuid(),
+		remarks: SE.string('Remarks'),
+	},
+	xml: 'Public/MarketingTeam',
+});
+
+export const defMarketingTeamEntry = SED({
+	required: ['uuid', 'marketing_team_uuid', 'marketing_uuid', 'created_at'],
+	properties: {
+		uuid: SE.uuid(),
+		marketing_team_uuid: SE.uuid(),
+		marketing_uuid: SE.uuid(),
+		is_team_leader: SE.boolean(),
+		created_at: SE.date_time(),
+		updated_at: SE.date_time(),
+		created_by: SE.uuid(),
+		remarks: SE.string('Remarks'),
+	},
+	xml: 'Public/MarketingTeamEntry',
+});
+
+export const defMarketingTeamMemberTarget = {
+	required: [
+		'uuid',
+		'marketing_uuid',
+		'year',
+		'month',
+		'amount',
+		'created_at',
+		'created_by',
+	],
+
+	properties: {
+		uuid: SE.uuid(),
+		marketing_uuid: SE.uuid(),
+		year: SE.integer(),
+		month: SE.integer(),
+		amount: SE.number(),
+		created_at: SE.date_time(),
+		updated_at: SE.date_time(),
+		created_by: SE.uuid(),
+		remarks: SE.string('Remarks'),
+	},
+	xml: 'Public/MarketingTeamMemberTarget',
+};
+
 // * Marge All
 export const defPublic = {
 	buyer: defPublicBuyer,
@@ -187,6 +240,9 @@ export const defPublic = {
 	section: defPublicSection,
 	properties: defPublicProperties,
 	machine: defMachine,
+	marketing_team: defMarketingTeam,
+	marketing_team_entry: defMarketingTeamEntry,
+	marketing_team_member_target: defMarketingTeamMemberTarget,
 };
 
 // * Tag
@@ -222,5 +278,18 @@ export const tagPublic = [
 	{
 		name: 'public.machine',
 		description: 'Machine',
+	},
+
+	{
+		name: 'public.marketing_team',
+		description: 'marketing_team',
+	},
+	{
+		name: 'public.marketing_team_entry',
+		description: 'marketing_team_entry',
+	},
+	{
+		name: 'public.marketing_team_member_target',
+		description: 'marketing_team_member_target',
 	},
 ];

--- a/src/db/public/swagger/route.js
+++ b/src/db/public/swagger/route.js
@@ -53,12 +53,11 @@ const pathPublicBuyer = {
 				{
 					name: 'uuid',
 					in: 'path',
+					description: ' UUID',
 					required: true,
-					description: 'uuid of the buyer',
-					schema: {
-						type: 'string',
-						format: 'uuid',
-					},
+					type: 'string',
+					format: 'uuid',
+					example: 'igD0v9DIJQhJeet',
 				},
 			],
 			responses: {
@@ -82,12 +81,11 @@ const pathPublicBuyer = {
 				{
 					name: 'uuid',
 					in: 'path',
+					description: ' UUID',
 					required: true,
-					description: 'uuid of the buyer',
-					schema: {
-						type: 'string',
-						format: 'uuid',
-					},
+					type: 'string',
+					format: 'uuid',
+					example: 'igD0v9DIJQhJeet',
 				},
 			],
 			requestBody: {
@@ -113,12 +111,11 @@ const pathPublicBuyer = {
 				{
 					name: 'uuid',
 					in: 'path',
+					description: ' UUID',
 					required: true,
-					description: 'uuid of the buyer',
-					schema: {
-						type: 'string',
-						format: 'uuid',
-					},
+					type: 'string',
+					format: 'uuid',
+					example: 'igD0v9DIJQhJeet',
 				},
 			],
 			responses: {
@@ -214,12 +211,11 @@ const pathPublicFactory = {
 				{
 					name: 'uuid',
 					in: 'path',
+					description: ' UUID',
 					required: true,
-					description: 'uuid of the factory',
-					schema: {
-						type: 'string',
-						format: 'uuid',
-					},
+					type: 'string',
+					format: 'uuid',
+					example: 'igD0v9DIJQhJeet',
 				},
 			],
 			responses: {
@@ -243,12 +239,11 @@ const pathPublicFactory = {
 				{
 					name: 'uuid',
 					in: 'path',
+					description: ' UUID',
 					required: true,
-					description: 'uuid of the factory',
-					schema: {
-						type: 'string',
-						format: 'uuid',
-					},
+					type: 'string',
+					format: 'uuid',
+					example: 'igD0v9DIJQhJeet',
 				},
 			],
 			requestBody: {
@@ -274,12 +269,11 @@ const pathPublicFactory = {
 				{
 					name: 'uuid',
 					in: 'path',
+					description: ' UUID',
 					required: true,
-					description: 'uuid of the factory',
-					schema: {
-						type: 'string',
-						format: 'uuid',
-					},
+					type: 'string',
+					format: 'uuid',
+					example: 'igD0v9DIJQhJeet',
 				},
 			],
 			responses: {
@@ -346,12 +340,11 @@ const pathPublicMarketing = {
 				{
 					name: 'uuid',
 					in: 'path',
+					description: ' UUID',
 					required: true,
-					description: 'uuid of the marketing',
-					schema: {
-						type: 'string',
-						format: 'uuid',
-					},
+					type: 'string',
+					format: 'uuid',
+					example: 'igD0v9DIJQhJeet',
 				},
 			],
 			responses: {
@@ -375,12 +368,11 @@ const pathPublicMarketing = {
 				{
 					name: 'uuid',
 					in: 'path',
+					description: ' UUID',
 					required: true,
-					description: 'uuid of the marketing',
-					schema: {
-						type: 'string',
-						format: 'uuid',
-					},
+					type: 'string',
+					format: 'uuid',
+					example: 'igD0v9DIJQhJeet',
 				},
 			],
 			requestBody: {
@@ -406,12 +398,11 @@ const pathPublicMarketing = {
 				{
 					name: 'uuid',
 					in: 'path',
+					description: ' UUID',
 					required: true,
-					description: 'uuid of the marketing',
-					schema: {
-						type: 'string',
-						format: 'uuid',
-					},
+					type: 'string',
+					format: 'uuid',
+					example: 'igD0v9DIJQhJeet',
 				},
 			],
 			responses: {
@@ -510,12 +501,11 @@ const pathPublicMerchandiser = {
 				{
 					name: 'uuid',
 					in: 'path',
+					description: ' UUID',
 					required: true,
-					description: 'uuid of the merchandiser',
-					schema: {
-						type: 'string',
-						format: 'uuid',
-					},
+					type: 'string',
+					format: 'uuid',
+					example: 'igD0v9DIJQhJeet',
 				},
 			],
 			responses: {
@@ -571,12 +561,11 @@ const pathPublicMerchandiser = {
 				{
 					name: 'uuid',
 					in: 'path',
+					description: ' UUID',
 					required: true,
-					description: 'uuid of the merchandiser',
-					schema: {
-						type: 'string',
-						format: 'uuid',
-					},
+					type: 'string',
+					format: 'uuid',
+					example: 'igD0v9DIJQhJeet',
 				},
 			],
 			requestBody: {
@@ -602,12 +591,11 @@ const pathPublicMerchandiser = {
 				{
 					name: 'uuid',
 					in: 'path',
+					description: ' UUID',
 					required: true,
-					description: 'uuid of the merchandiser',
-					schema: {
-						type: 'string',
-						format: 'uuid',
-					},
+					type: 'string',
+					format: 'uuid',
+					example: 'igD0v9DIJQhJeet',
 				},
 			],
 			responses: {
@@ -673,12 +661,11 @@ const pathPublicParty = {
 				{
 					name: 'uuid',
 					in: 'path',
+					description: ' UUID',
 					required: true,
-					description: 'uuid of the party',
-					schema: {
-						type: 'string',
-						format: 'uuid',
-					},
+					type: 'string',
+					format: 'uuid',
+					example: 'igD0v9DIJQhJeet',
 				},
 			],
 			responses: {
@@ -702,12 +689,11 @@ const pathPublicParty = {
 				{
 					name: 'uuid',
 					in: 'path',
+					description: ' UUID',
 					required: true,
-					description: 'uuid of the party',
-					schema: {
-						type: 'string',
-						format: 'uuid',
-					},
+					type: 'string',
+					format: 'uuid',
+					example: 'igD0v9DIJQhJeet',
 				},
 			],
 			requestBody: {
@@ -733,12 +719,11 @@ const pathPublicParty = {
 				{
 					name: 'uuid',
 					in: 'path',
+					description: ' UUID',
 					required: true,
-					description: 'uuid of the party',
-					schema: {
-						type: 'string',
-						format: 'uuid',
-					},
+					type: 'string',
+					format: 'uuid',
+					example: 'igD0v9DIJQhJeet',
 				},
 			],
 			responses: {
@@ -842,12 +827,11 @@ const pathPublicProperties = {
 				{
 					name: 'uuid',
 					in: 'path',
+					description: ' UUID',
 					required: true,
-					description: 'uuid of the properties',
-					schema: {
-						type: 'string',
-						format: 'uuid',
-					},
+					type: 'string',
+					format: 'uuid',
+					example: 'igD0v9DIJQhJeet',
 				},
 			],
 			responses: {
@@ -977,12 +961,11 @@ const pathPublicProperties = {
 				{
 					name: 'uuid',
 					in: 'path',
+					description: ' UUID',
 					required: true,
-					description: 'uuid of the properties',
-					schema: {
-						type: 'string',
-						format: 'uuid',
-					},
+					type: 'string',
+					format: 'uuid',
+					example: 'igD0v9DIJQhJeet',
 				},
 			],
 			responses: {
@@ -1048,12 +1031,11 @@ const pathPublicSection = {
 				{
 					name: 'uuid',
 					in: 'path',
+					description: ' UUID',
 					required: true,
-					description: 'uuid of the section',
-					schema: {
-						type: 'string',
-						format: 'uuid',
-					},
+					type: 'string',
+					format: 'uuid',
+					example: 'igD0v9DIJQhJeet',
 				},
 			],
 			responses: {
@@ -1077,12 +1059,11 @@ const pathPublicSection = {
 				{
 					name: 'uuid',
 					in: 'path',
+					description: ' UUID',
 					required: true,
-					description: 'uuid of the section',
-					schema: {
-						type: 'string',
-						format: 'uuid',
-					},
+					type: 'string',
+					format: 'uuid',
+					example: 'igD0v9DIJQhJeet',
 				},
 			],
 			requestBody: {
@@ -1108,12 +1089,11 @@ const pathPublicSection = {
 				{
 					name: 'uuid',
 					in: 'path',
+					description: ' UUID',
 					required: true,
-					description: 'uuid of the section',
-					schema: {
-						type: 'string',
-						format: 'uuid',
-					},
+					type: 'string',
+					format: 'uuid',
+					example: 'igD0v9DIJQhJeet',
 				},
 			],
 			responses: {
@@ -1178,12 +1158,11 @@ export const publicMachine = {
 				{
 					name: 'uuid',
 					in: 'path',
+					description: ' UUID',
 					required: true,
-					description: 'uuid of the machine',
-					schema: {
-						type: 'string',
-						format: 'uuid',
-					},
+					type: 'string',
+					format: 'uuid',
+					example: 'igD0v9DIJQhJeet',
 				},
 			],
 			responses: {
@@ -1207,12 +1186,11 @@ export const publicMachine = {
 				{
 					name: 'uuid',
 					in: 'path',
+					description: ' UUID',
 					required: true,
-					description: 'uuid of the section',
-					schema: {
-						type: 'string',
-						format: 'uuid',
-					},
+					type: 'string',
+					format: 'uuid',
+					example: 'igD0v9DIJQhJeet',
 				},
 			],
 			requestBody: {
@@ -1238,8 +1216,626 @@ export const publicMachine = {
 				{
 					name: 'uuid',
 					in: 'path',
+					description: ' UUID',
 					required: true,
-					description: 'uuid of the machine',
+					type: 'string',
+					format: 'uuid',
+					example: 'igD0v9DIJQhJeet',
+				},
+			],
+			responses: {
+				204: {
+					description: 'No Content',
+				},
+			},
+		},
+	},
+};
+
+export const publicMarketingTeam = {
+	'/public/marketing-team': {
+		get: {
+			summary: 'Get all marketing teams',
+			tags: ['public.marketing_team'],
+			operationId: 'getMarketingTeams',
+			parameters: [],
+			responses: {
+				200: {
+					description: 'OK',
+					content: {
+						'application/json': {
+							schema: {
+								type: 'object',
+								properties: {
+									uuid: {
+										type: 'string',
+										example: 'igD0v9DIJQhJeet',
+									},
+									name: {
+										type: 'string',
+										example: 'prop 1',
+									},
+
+									created_by: {
+										type: 'string',
+										example: 'igD0v9DIJQhJeet',
+									},
+									created_by_name: {
+										type: 'string',
+										example: 'John Doe',
+									},
+									created_at: {
+										type: 'string',
+										example: '2024-01-01 00:00:00',
+									},
+									updated_at: {
+										type: 'string',
+										example: '2024-01-01 00:00:00',
+									},
+									remarks: {
+										type: 'string',
+										example: 'remarks',
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		post: {
+			summary: 'Create a marketing team',
+			tags: ['public.marketing_team'],
+			operationId: 'createMarketingTeam',
+			parameters: [],
+			requestBody: {
+				content: {
+					'application/json': {
+						schema: {
+							$ref: '#/definitions/public/marketing_team',
+						},
+					},
+				},
+			},
+			responses: {
+				201: {
+					description: 'Created',
+				},
+			},
+		},
+	},
+
+	'/public/marketing-team/{uuid}': {
+		get: {
+			summary: 'Get a marketing team',
+			tags: ['public.marketing_team'],
+			operationId: 'getMarketingTeam',
+			parameters: [
+				{
+					name: 'uuid',
+					in: 'path',
+					description: ' UUID',
+					required: true,
+					type: 'string',
+					format: 'uuid',
+					example: 'igD0v9DIJQhJeet',
+				},
+			],
+			responses: {
+				200: {
+					description: 'OK',
+					content: {
+						'application/json': {
+							schema: {
+								type: 'object',
+								properties: {
+									uuid: {
+										type: 'string',
+										example: 'igD0v9DIJQhJeet',
+									},
+									name: {
+										type: 'string',
+										example: 'prop 1',
+									},
+
+									created_by: {
+										type: 'string',
+										example: 'igD0v9DIJQhJeet',
+									},
+									created_by_name: {
+										type: 'string',
+										example: 'John Doe',
+									},
+									created_at: {
+										type: 'string',
+										example: '2024-01-01 00:00:00',
+									},
+									updated_at: {
+										type: 'string',
+										example: '2024-01-01 00:00:00',
+									},
+									remarks: {
+										type: 'string',
+										example: 'remarks',
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		put: {
+			summary: 'Update a marketing team',
+			tags: ['public.marketing_team'],
+			operationId: 'updateMarketingTeam',
+			parameters: [
+				{
+					name: 'uuid',
+					in: 'path',
+					description: ' UUID',
+					required: true,
+					type: 'string',
+					format: 'uuid',
+					example: 'igD0v9DIJQhJeet',
+				},
+			],
+			requestBody: {
+				content: {
+					'application/json': {
+						schema: {
+							$ref: '#/definitions/public/marketing_team',
+						},
+					},
+				},
+			},
+			responses: {
+				204: {
+					description: 'No Content',
+				},
+			},
+		},
+		delete: {
+			summary: 'Delete a marketing team',
+			tags: ['public.marketing_team'],
+			operationId: 'deleteMarketingTeam',
+			parameters: [
+				{
+					name: 'uuid',
+					in: 'path',
+					description: ' UUID',
+					required: true,
+					type: 'string',
+					format: 'uuid',
+					example: 'igD0v9DIJQhJeet',
+				},
+			],
+			responses: {
+				204: {
+					description: 'No Content',
+				},
+			},
+		},
+	},
+};
+
+export const publicMarketingTeamEntry = {
+	'/public/marketing-team-entry': {
+		get: {
+			summary: 'Get all marketing team entries',
+			tags: ['public.marketing_team_entry'],
+			operationId: 'getMarketingTeamEntries',
+			parameters: [],
+			responses: {
+				200: {
+					description: 'OK',
+					content: {
+						'application/json': {
+							schema: {
+								type: 'object',
+								properties: {
+									uuid: {
+										type: 'string',
+										example: 'igD0v9DIJQhJeet',
+									},
+									marketing_team_uuid: {
+										type: 'string',
+										example: 'igD0v9DIJQhJeet',
+									},
+									marketing_team_name: {
+										type: 'string',
+										example: 'prop 1',
+									},
+									marketing_uuid: {
+										type: 'string',
+										example: 'igD0v9DIJQhJeet',
+									},
+									marketing_name: {
+										type: 'string',
+										example: 'prop 1',
+									},
+									created_by: {
+										type: 'string',
+										example: 'igD0v9DIJQhJeet',
+									},
+									created_by_name: {
+										type: 'string',
+										example: 'John Doe',
+									},
+									created_at: {
+										type: 'string',
+										example: '2024-01-01 00:00:00',
+									},
+									updated_at: {
+										type: 'string',
+										example: '2024-01-01 00:00:00',
+									},
+									remarks: {
+										type: 'string',
+										example: 'remarks',
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		post: {
+			summary: 'Create a marketing team entry',
+			tags: ['public.marketing_team_entry'],
+			operationId: 'createMarketingTeamEntry',
+			parameters: [],
+			requestBody: {
+				content: {
+					'application/json': {
+						schema: {
+							$ref: '#/definitions/public/marketing_team_entry',
+						},
+					},
+				},
+			},
+			responses: {
+				201: {
+					description: 'Created',
+				},
+			},
+		},
+	},
+
+	'/public/marketing-team-entry/{uuid}': {
+		get: {
+			summary: 'Get a marketing team entry',
+			tags: ['public.marketing_team_entry'],
+			operationId: 'getMarketingTeamEntry',
+			parameters: [
+				{
+					name: 'uuid',
+					in: 'path',
+					description: ' UUID',
+					required: true,
+					type: 'string',
+					format: 'uuid',
+					example: 'igD0v9DIJQhJeet',
+				},
+			],
+			responses: {
+				200: {
+					description: 'OK',
+					content: {
+						'application/json': {
+							schema: {
+								type: 'object',
+								properties: {
+									uuid: {
+										type: 'string',
+										example: 'igD0v9DIJQhJeet',
+									},
+									marketing_team_uuid: {
+										type: 'string',
+										example: 'igD0v9DIJQhJeet',
+									},
+									marketing_team_name: {
+										type: 'string',
+										example: 'prop 1',
+									},
+									marketing_uuid: {
+										type: 'string',
+										example: 'igD0v9DIJQhJeet',
+									},
+									marketing_name: {
+										type: 'string',
+										example: 'prop 1',
+									},
+									created_by: {
+										type: 'string',
+										example: 'igD0v9DIJQhJeet',
+									},
+									created_by_name: {
+										type: 'string',
+										example: 'John Doe',
+									},
+									created_at: {
+										type: 'string',
+										example: '2024-01-01 00:00:00',
+									},
+									updated_at: {
+										type: 'string',
+										example: '2024-01-01 00:00:00',
+									},
+									remarks: {
+										type: 'string',
+										example: 'remarks',
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		put: {
+			summary: 'Update a marketing team entry',
+			tags: ['public.marketing_team_entry'],
+			operationId: 'updateMarketingTeamEntry',
+			parameters: [
+				{
+					name: 'uuid',
+					in: 'path',
+					description: ' UUID',
+					required: true,
+					type: 'string',
+					format: 'uuid',
+					example: 'igD0v9DIJQhJeet',
+				},
+			],
+			requestBody: {
+				content: {
+					'application/json': {
+						schema: {
+							$ref: '#/definitions/public/marketing_team_entry',
+						},
+					},
+				},
+			},
+			responses: {
+				204: {
+					description: 'No Content',
+				},
+			},
+		},
+		delete: {
+			summary: 'Delete a marketing team entry',
+			tags: ['public.marketing_team_entry'],
+			operationId: 'deleteMarketingTeamEntry',
+			parameters: [
+				{
+					name: 'uuid',
+					in: 'path',
+					required: true,
+					description: 'uuid of the marketing team entry',
+					schema: {
+						type: 'string',
+						format: 'uuid',
+					},
+				},
+			],
+			responses: {
+				204: {
+					description: 'No Content',
+				},
+			},
+		},
+	},
+};
+
+export const publicMarketingTeamMemberTarget = {
+	'/public/marketing-team-member-target': {
+		get: {
+			summary: 'Get all marketing team member targets',
+			tags: ['public.marketing_team_member_target'],
+			operationId: 'getMarketingTeamMemberTargets',
+			parameters: [],
+			responses: {
+				200: {
+					description: 'OK',
+					content: {
+						'application/json': {
+							schema: {
+								type: 'object',
+								properties: {
+									uuid: {
+										type: 'string',
+										example: 'igD0v9DIJQhJeet',
+									},
+
+									marketing_uuid: {
+										type: 'string',
+										example: 'igD0v9DIJQhJeet',
+									},
+									marketing_name: {
+										type: 'string',
+										example: 'prop 1',
+									},
+									year: {
+										type: 'string',
+										example: '2024',
+									},
+									month: {
+										type: 'string',
+										example: '01',
+									},
+									amount: {
+										type: 'string',
+										example: '1000',
+									},
+
+									created_by: {
+										type: 'string',
+										example: 'igD0v9DIJQhJeet',
+									},
+									created_by_name: {
+										type: 'string',
+										example: 'John Doe',
+									},
+									created_at: {
+										type: 'string',
+										example: '2024-01-01 00:00:00',
+									},
+									updated_at: {
+										type: 'string',
+										example: '2024-01-01 00:00:00',
+									},
+									remarks: {
+										type: 'string',
+										example: 'remarks',
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		post: {
+			summary: 'Create a marketing team member target',
+			tags: ['public.marketing_team_member_target'],
+			operationId: 'createMarketingTeamMemberTarget',
+			parameters: [],
+			requestBody: {
+				content: {
+					'application/json': {
+						schema: {
+							$ref: '#/definitions/public/marketing_team_member_target',
+						},
+					},
+				},
+			},
+			responses: {
+				201: {
+					description: 'Created',
+				},
+			},
+		},
+	},
+
+	'/public/marketing-team-member-target/{uuid}': {
+		get: {
+			summary: 'Get a marketing team member target',
+			tags: ['public.marketing_team_member_target'],
+			operationId: 'getMarketingTeamMemberTarget',
+			parameters: [
+				{
+					name: 'uuid',
+					in: 'path',
+					description: ' UUID',
+					required: true,
+					type: 'string',
+					format: 'uuid',
+					example: 'igD0v9DIJQhJeet',
+				},
+			],
+			responses: {
+				200: {
+					description: 'OK',
+					content: {
+						'application/json': {
+							schema: {
+								type: 'object',
+								properties: {
+									uuid: {
+										type: 'string',
+										example: 'igD0v9DIJQhJeet',
+									},
+
+									marketing_uuid: {
+										type: 'string',
+										example: 'igD0v9DIJQhJeet',
+									},
+									marketing_name: {
+										type: 'string',
+										example: 'prop 1',
+									},
+									year: {
+										type: 'string',
+										example: '2024',
+									},
+									month: {
+										type: 'string',
+										example: '01',
+									},
+									amount: {
+										type: 'string',
+										example: '1000',
+									},
+
+									created_by: {
+										type: 'string',
+										example: 'igD0v9DIJQhJeet',
+									},
+									created_by_name: {
+										type: 'string',
+										example: 'John Doe',
+									},
+									created_at: {
+										type: 'string',
+										example: '2024-01-01 00:00:00',
+									},
+									updated_at: {
+										type: 'string',
+										example: '2024-01-01 00:00:00',
+									},
+									remarks: {
+										type: 'string',
+										example: 'remarks',
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		put: {
+			summary: 'Update a marketing team member target',
+			tags: ['public.marketing_team_member_target'],
+			operationId: 'updateMarketingTeamMemberTarget',
+			parameters: [
+				{
+					name: 'uuid',
+					in: 'path',
+					description: ' UUID',
+					required: true,
+					type: 'string',
+					format: 'uuid',
+					example: 'igD0v9DIJQhJeet',
+				},
+			],
+			requestBody: {
+				content: {
+					'application/json': {
+						schema: {
+							$ref: '#/definitions/public/marketing_team_member_target',
+						},
+					},
+				},
+			},
+			responses: {
+				204: {
+					description: 'No Content',
+				},
+			},
+		},
+		delete: {
+			summary: 'Delete a marketing team member target',
+			tags: ['public.marketing_team_member_target'],
+			operationId: 'deleteMarketingTeamMemberTarget',
+			parameters: [
+				{
+					name: 'uuid',
+					in: 'path',
+					required: true,
+					description: 'uuid of the marketing team member target',
 					schema: {
 						type: 'string',
 						format: 'uuid',
@@ -1264,4 +1860,7 @@ export const pathPublic = {
 	...pathPublicProperties,
 	...pathPublicSection,
 	...publicMachine,
+	...publicMarketingTeam,
+	...publicMarketingTeamEntry,
+	...publicMarketingTeamMemberTarget,
 };


### PR DESCRIPTION
Introduce a new database schema for marketing teams and related entries, along with corresponding API routes for CRUD operations. This enhances the application's capability to manage marketing team data effectively.