### PR TITLE
Add API endpoint for retrieving all challans with UUIDs and formatted labels

### DIFF
--- a/src/db/others/query/query.js
+++ b/src/db/others/query/query.js
@@ -1563,3 +1563,29 @@ export async function selectCarton(req, res, next) {
 		await handleError({ error, res });
 	}
 }
+
+export async function selectChallan(req, res, next) {
+	const query = sql`
+	SELECT
+		ch.uuid AS value,
+		concat('CH', to_char(ch.created_at, 'YY'), '-', LPAD(ch.id::text, 4, '0')) AS label
+	FROM
+		delivery.challan ch
+	`;
+
+	const challanPromise = db.execute(query);
+
+	try {
+		const data = await challanPromise;
+
+		const toast = {
+			status: 200,
+			type: 'select_all',
+			message: 'Challan list',
+		};
+
+		res.status(200).json({ toast, data: data?.rows });
+	} catch (error) {
+		await handleError({ error, res });
+	}
+}

--- a/src/db/others/route.js
+++ b/src/db/others/route.js
@@ -147,6 +147,9 @@ otherRouter.get(
 	otherOperations.selectPackingListByOrderInfoUuid
 );
 
+// challan
+otherRouter.get('/delivery/challan/value/label', otherOperations.selectChallan);
+
 // vehicle
 otherRouter.get('/delivery/vehicle/value/label', otherOperations.selectVehicle);
 
@@ -1472,6 +1475,30 @@ const pathDelivery = {
 								properties: {
 									value: SE.uuid(),
 									label: SE.string('10*10*10'),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	},
+	'/other/delivery/challan/value/label': {
+		get: {
+			tags: ['others'],
+			summary: 'get all challans',
+			description: 'All challans',
+			operationId: 'getAllChallans',
+			responses: {
+				200: {
+					description: 'Returns a all challans.',
+					content: {
+						'application/json': {
+							schema: {
+								type: 'object',
+								properties: {
+									value: SE.uuid(),
+									label: SE.string('CH24-0001'),
 								},
 							},
 						},


### PR DESCRIPTION
Introduce a new API endpoint to fetch all challans, providing their UUIDs and formatted labels for easier identification.