### PR TITLE
Add filtering by challan_uuid to selectAll packing lists endpoint

### DIFF
--- a/src/db/delivery/query/packing_list.js
+++ b/src/db/delivery/query/packing_list.js
@@ -77,12 +77,15 @@ export async function remove(req, res, next) {
 }
 
 export async function selectAll(req, res, next) {
+	const { challan_uuid } = req.query;
+
 	const query = sql`
 		SELECT dvl.*,
 		SUM(ple.quantity)::float8 as total_quantity,
 		SUM(ple.poli_quantity)::float8 as total_poly_quantity
 		FROM delivery.v_packing_list dvl
 		LEFT JOIN delivery.packing_list_entry ple ON dvl.uuid = ple.packing_list_uuid
+		${challan_uuid ? sql`WHERE dvl.challan_uuid = ${challan_uuid}` : sql``}
 		GROUP BY 
 			dvl.uuid,
 			dvl.order_info_uuid,

--- a/src/db/delivery/swagger/route.js
+++ b/src/db/delivery/swagger/route.js
@@ -9,6 +9,8 @@ export const pathDeliveryPackingList = {
 			summary: 'Get all packing lists',
 			description: 'Get all packing lists',
 			// operationId: "getPackingList",
+			parameters: [SE.parameter_query('challan_uuid', 'challan_uuid')],
+
 			responses: {
 				200: {
 					description: 'Return list of packing lists',


### PR DESCRIPTION
Introduce a query parameter for `challan_uuid` to filter results in the `selectAll` packing lists endpoint. Update the API documentation to reflect this new parameter.