### PR TITLE
Update marketing team entry routes to include 'by' in endpoints

### DIFF
--- a/src/db/public/query/marketing_team.js
+++ b/src/db/public/query/marketing_team.js
@@ -163,7 +163,7 @@ export async function selectMarketingTeamDetailsByMarketingTeamUuid(
 
 		const [marketing_team, marketing_team_entry] = await Promise.all([
 			fetchData('/public/marketing-team'),
-			fetchData('/public/marketing-team-entry'),
+			fetchData('/public/marketing-team-entry/by'),
 		]);
 
 		const response = {

--- a/src/db/public/query/marketing_team_entry.js
+++ b/src/db/public/query/marketing_team_entry.js
@@ -171,6 +171,10 @@ export async function selectAll(req, res, next) {
 }
 
 export async function selectAllByMarketingTeamUuid(req, res, next) {
+	console.log(
+		'req.params.marketing_team_uuid',
+		req.params.marketing_team_uuid
+	);
 	const marketing_team_entryPromise = db
 		.select({
 			uuid: marketing_team_entry.uuid,

--- a/src/db/public/route.js
+++ b/src/db/public/route.js
@@ -169,7 +169,7 @@ publicRouter.delete(
 	marketingTeamEntryOperations.remove
 );
 publicRouter.get(
-	'/marketing-team-entry/:marketing_team_uuid',
+	'/marketing-team-entry/by/:marketing_team_uuid',
 	marketingTeamEntryOperations.selectAllByMarketingTeamUuid
 );
 

--- a/src/db/public/swagger/route.js
+++ b/src/db/public/swagger/route.js
@@ -1661,7 +1661,7 @@ export const publicMarketingTeamEntry = {
 			},
 		},
 	},
-	'/public/marketing-team-entry/{marketing_team_uuid}': {
+	'/public/marketing-team-entry/by/{marketing_team_uuid}': {
 		get: {
 			summary: 'Get all marketing team entries',
 			tags: ['public.marketing_team_entry'],


### PR DESCRIPTION
Update the marketing team entry routes and queries to include 'by' in the endpoint for better clarity and organization. This change enhances the API structure for fetching marketing team entries.