### PR TITLE
Remove thread_order_info_uuid from packing list queries

### DIFF
--- a/src/db/delivery/query/packing_list.js
+++ b/src/db/delivery/query/packing_list.js
@@ -103,7 +103,6 @@ export async function selectAll(req, res, next) {
 		GROUP BY 
 			dvl.uuid,
 			dvl.order_info_uuid,
-			dvl.thread_order_info_uuid,
 			dvl.packing_list_wise_rank,
 			dvl.packing_list_wise_count,
 			dvl.packing_number,
@@ -158,7 +157,6 @@ export async function select(req, res, next) {
 		GROUP BY 
 			dvl.uuid,
 			dvl.order_info_uuid,
-			dvl.thread_order_info_uuid,
 			dvl.packing_list_wise_rank,
 			dvl.packing_list_wise_count,
 			dvl.packing_number,


### PR DESCRIPTION
Eliminate unnecessary grouping by thread_order_info_uuid in packing list queries to streamline data retrieval.