### PR TITLE
Add max_quantity calculation to packing list entry query

### DIFF
--- a/src/db/delivery/query/packing_list_entry.js
+++ b/src/db/delivery/query/packing_list_entry.js
@@ -263,7 +263,8 @@ export async function selectPackingListEntryByPackingListUuid(req, res, next) {
 			sfg.uuid as sfg_uuid,
 			CASE WHEN sfg.uuid IS NOT NULL THEN sfg.warehouse::float8 ELSE toe.warehouse::float8 END as warehouse,
 			CASE WHEN sfg.uuid IS NOT NULL THEN  sfg.delivered::float8 ELSE toe.delivered::float8 END as delivered,
-			CASE WHEN sfg.uuid IS NOT NULL THEN (oe.quantity::float8 - sfg.warehouse::float8 - sfg.delivered::float8)::float8 ELSE (toe.quantity - toe.warehouse - toe.delivered)::float8 END as balance_quantity
+			CASE WHEN sfg.uuid IS NOT NULL THEN (oe.quantity::float8 - sfg.warehouse::float8 - sfg.delivered::float8)::float8 ELSE (toe.quantity - toe.warehouse - toe.delivered)::float8 END as balance_quantity,
+			CASE WHEN sfg.uuid IS NOT NULL THEN (ple.quantity + oe.quantity - sfg.warehouse - sfg.delivered)::float8 ELSE (ple.quantity + toe.quantity - toe.warehouse - toe.delivered)::float8 END as max_quantity
 		FROM 
 			delivery.packing_list_entry ple
 		LEFT JOIN 


### PR DESCRIPTION
Calculate `max_quantity` in the packing list entry query based on the presence of `sfg_uuid`. This enhances the query to provide additional data for packing list entries.