### PR TITLE
Add handling for thread order UUIDs in packing list updates

### DIFF
--- a/src/db/delivery/query/packing_list.js
+++ b/src/db/delivery/query/packing_list.js
@@ -38,6 +38,8 @@ export async function insert(req, res, next) {
 export async function update(req, res, next) {
 	if (!(await validateRequest(req, next))) return;
 
+	const { item_for } = req.body;
+
 	if (item_for == 'thread') {
 		const { order_info_uuid } = req.body;
 		req.body.thread_order_info_uuid = order_info_uuid;

--- a/src/db/delivery/query/packing_list_entry.js
+++ b/src/db/delivery/query/packing_list_entry.js
@@ -34,6 +34,12 @@ export async function insert(req, res, next) {
 export async function update(req, res, next) {
 	if (!(await validateRequest(req, next))) return;
 
+	const { order_entry_uuid } = req.body;
+
+	if (order_entry_uuid !== null) {
+		req.body.thread_order_entry_uuid = order_entry_uuid;
+	}
+
 	const packing_list_entryPromise = db
 		.update(packing_list_entry)
 		.set(req.body)


### PR DESCRIPTION
Introduce support for thread order UUIDs in the packing list update functions to enhance data handling for thread-related entries.