### PR TITLE
Update thread order selection criteria to use packing list

### DIFF
--- a/src/db/others/query/query.js
+++ b/src/db/others/query/query.js
@@ -1340,11 +1340,11 @@ export async function selectThreadOrder(req, res, next) {
 								page == 'challan'
 									? sql`ot.uuid IN (
 								SELECT
-									oe.order_info_uuid
+									pl.thread_order_info_uuid
 								FROM
-									thread.order_entry oe
+									delivery.packing_list pl
 								WHERE
-									oe.warehouse > 0)`
+									pl.challan_uuid IS NULL AND pl.is_warehouse_received = true)`
 									: sql`1=1`
 							}`;
 


### PR DESCRIPTION
Revise the `selectThreadOrder` function to reference the packing list for order selection criteria, improving the accuracy of the order retrieval process.