### PR TITLE
Update packing list query to include warehouse received condition

### DIFF
--- a/src/db/others/query/query.js
+++ b/src/db/others/query/query.js
@@ -1513,7 +1513,7 @@ export async function selectPackingListByOrderInfoUuid(req, res, next) {
     FROM
         delivery.packing_list pl
     WHERE
-        (pl.order_info_uuid = ${order_info_uuid} OR pl.thread_order_info_uuid = ${order_info_uuid}) AND (pl.challan_uuid IS NULL`;
+        (pl.order_info_uuid = ${order_info_uuid} OR pl.thread_order_info_uuid = ${order_info_uuid}) AND ((pl.challan_uuid IS NULL`;
 
 	// Conditionally add the challan_uuid part
 	if (
@@ -1521,7 +1521,9 @@ export async function selectPackingListByOrderInfoUuid(req, res, next) {
 		challan_uuid != '' &&
 		challan_uuid != 'null'
 	) {
-		query.append(sql` OR pl.challan_uuid = ${challan_uuid}`);
+		query.append(
+			sql` OR pl.challan_uuid = ${challan_uuid}) AND pl.is_warehouse_received = true`
+		);
 	}
 	query.append(sql`)`);
 


### PR DESCRIPTION
The query for selecting packing lists now includes a condition to check if the items have been received in the warehouse. This change enhances the accuracy of the data retrieved based on the order information.