### PR TITLE
Add filtering by gate pass status in selectChallan function

### DIFF
--- a/src/db/others/query/query.js
+++ b/src/db/others/query/query.js
@@ -1682,13 +1682,16 @@ export async function selectCarton(req, res, next) {
 }
 
 export async function selectChallan(req, res, next) {
+	const { get_pass } = req.query;
 	const query = sql`
-	SELECT
-		ch.uuid AS value,
-		concat('CH', to_char(ch.created_at, 'YY'), '-', LPAD(ch.id::text, 4, '0')) AS label
-	FROM
-		delivery.challan ch
-	`;
+				SELECT
+					ch.uuid AS value,
+					concat('CH', to_char(ch.created_at, 'YY'), '-', LPAD(ch.id::text, 4, '0')) AS label
+				FROM
+					delivery.challan ch 
+				WHERE 
+					${get_pass == 0 ? sql`ch.gate_pass = 0` : sql`1=1`}
+				`;
 
 	const challanPromise = db.execute(query);
 

--- a/src/db/others/route.js
+++ b/src/db/others/route.js
@@ -1495,6 +1495,7 @@ const pathDelivery = {
 			summary: 'get all challans',
 			description: 'All challans',
 			operationId: 'getAllChallans',
+			parameters: [SE.parameter_query('get_pass', 'get_pass', [0, 1])],
 			responses: {
 				200: {
 					description: 'Returns a all challans.',


### PR DESCRIPTION
Introduce a `get_pass` query parameter to filter results based on gate pass status in the `selectChallan` function. Update API documentation to include the new parameter.