### PR TITLE
Update get_pass parameter handling in selectChallan function and route definition

### DIFF
--- a/src/db/others/query/query.js
+++ b/src/db/others/query/query.js
@@ -1690,7 +1690,7 @@ export async function selectChallan(req, res, next) {
 				FROM
 					delivery.challan ch 
 				WHERE 
-					${get_pass == 0 ? sql`ch.gate_pass = 0` : sql`1=1`}
+					${get_pass === 'false' ? sql`ch.gate_pass = 0` : sql`1=1`}
 				`;
 
 	const challanPromise = db.execute(query);

--- a/src/db/others/route.js
+++ b/src/db/others/route.js
@@ -1495,7 +1495,9 @@ const pathDelivery = {
 			summary: 'get all challans',
 			description: 'All challans',
 			operationId: 'getAllChallans',
-			parameters: [SE.parameter_query('get_pass', 'get_pass', [0, 1])],
+			parameters: [
+				SE.parameter_query('get_pass', 'get_pass', ['true', 'false']),
+			],
 			responses: {
 				200: {
 					description: 'Returns a all challans.',


### PR DESCRIPTION
Adjust the handling of the `get_pass` parameter in the `selectChallan` function and update the route definition to accept string values instead of integers.