### PR TITLE
Cast size to numeric type for improved data handling

### DIFF
--- a/src/db/delivery/query/packing_list_entry.js
+++ b/src/db/delivery/query/packing_list_entry.js
@@ -263,7 +263,7 @@ export async function selectPackingListEntryByPackingListUuid(req, res, next) {
 			END as size_cm,
 			CASE WHEN 
 				ple.sfg_uuid IS NOT NULL THEN 
-					oe.size
+					CAST(oe.size AS NUMERIC)
 				ELSE
 					tc.length
 			END as size,


### PR DESCRIPTION
Improve data handling by casting the size to a numeric type in the `selectPackingListEntryByPackingListUuid` function.