### PR TITLE
Add ordering by creation date in selectAll query for marketing team member targets

### DIFF
--- a/src/db/public/query/marketing_team_member_target.js
+++ b/src/db/public/query/marketing_team_member_target.js
@@ -151,7 +151,8 @@ export async function selectAll(req, res, next) {
 		.leftJoin(
 			hrSchema.users,
 			eq(marketing_team_member_target.created_by, hrSchema.users.uuid)
-		);
+		)
+		.orderBy(desc(marketing_team_member_target.created_at));
 
 	try {
 		const data = await marketing_team_member_targetPromise;


### PR DESCRIPTION
Implement ordering of marketing team member targets by their creation date in the selectAll query.