### PR TITLE
Add is_balance filter to selectOrderDescription query and comment out production_quantity

### DIFF
--- a/src/db/others/query/query.js
+++ b/src/db/others/query/query.js
@@ -506,8 +506,13 @@ export async function selectOrderEntry(req, res, next) {
 }
 
 export async function selectOrderDescription(req, res, next) {
-	const { item, tape_received, dyed_tape_required, swatch_approved } =
-		req.query;
+	const {
+		item,
+		tape_received,
+		dyed_tape_required,
+		swatch_approved,
+		is_balance,
+	} = req.query;
 
 	const query = sql`
 				SELECT
@@ -614,6 +619,11 @@ export async function selectOrderDescription(req, res, next) {
 
 	if (tape_received == 'true') {
 		query.append(sql` AND vodf.tape_received > 0`);
+	}
+	if (is_balance == 'true') {
+		query.append(
+			sql` AND coalesce(oe.quantity::float8,0) - coalesce(fbe_given.given_quantity::float8,0) > 0`
+		);
 	}
 
 	// , ' ⇾ ',  vodf.tape_received

--- a/src/db/zipper/query/finishing_batch.js
+++ b/src/db/zipper/query/finishing_batch.js
@@ -367,9 +367,9 @@ export async function getFinishingBatchCapacityDetails(req, res, next) {
 			production_capacity_quantity: decimalToNumber(
 				publicSchema.production_capacity.quantity
 			),
-			production_quantity: decimalToNumber(
-				sql`finishing_batch_entry_total.total_batch_quantity`
-			),
+			// production_quantity: decimalToNumber(
+			// 	sql`finishing_batch_entry_total.total_batch_quantity`
+			// ),
 			production_date: finishing_batch.production_date,
 		})
 		.from(finishing_batch)


### PR DESCRIPTION
Introduce an `is_balance` filter to the `selectOrderDescription` query for enhanced order selection. Comment out the `production_quantity` field in `getFinishingBatchCapacityDetails` to streamline the response.